### PR TITLE
changed the statcard names of the AV-8A/C, A-10A (1976/78), and F3H-2 so they aligned with the proper formatting

### DIFF
--- a/Mod Files/syrup_units_usa.csv
+++ b/Mod Files/syrup_units_usa.csv
@@ -672,7 +672,7 @@ noverify>";"<English>";
 "f-100d_2";"F-100D";;
 
 "f3h-2_shop";"F3H-2 Demon";;
-"f3h-2_0";"McDonnell F3H-2 Demon";;
+"f3h-2_0";"McDonnell Douglas Corporation | F3H-2 Demon";;
 "f3h-2_1";"F3H-2 Demon";;
 "f3h-2_2";"F3H-2";;
 
@@ -702,12 +702,12 @@ noverify>";"<English>";
 "fj_4b_agm_12b_2";"FJ-4B (VMF-232)";;
 
 "av_8a_shop";"▃AV-8A Harrier";;
-"av_8a_0";"▃Hawker Siddeley AV-8A Harrier";;
+"av_8a_0";"Hawker Siddeley Group, Ltd. | ▃AV-8A Harrier";;
 "av_8a_1";"▃AV-8A Harrier";;
 "av_8a_2";"▃AV-8A";;
 
 "av_8c_shop";"▃AV-8C Harrier";;
-"av_8c_0";"▃Hawker Siddeley AV-8C Harrier";;
+"av_8c_0";"Hawker Siddeley Group, Ltd. | ▃AV-8C Harrier";;
 "av_8c_1";"▃AV-8C Harrier";;
 "av_8c_2";"▃AV-8C";"AV-8";;
 
@@ -717,7 +717,7 @@ noverify>";"<English>";
 "f_117_2";"F-117A";;
 
 "a_10a_early_shop";"A-10A Warthog (1976)";;
-"a_10a_early_0";"Fairchild Republic A-10A Warthog (1976)";;
+"a_10a_early_0";"Fairchild Republic | A-10A Warthog (1976)";;
 "a_10a_early_1";"A-10A Warthog (1976)";;
 "a_10a_early_2";"A-10A (1976)";;
 
@@ -767,7 +767,7 @@ noverify>";"<English>";
 "f-4s_2";"F-4S";;
 
 "a_10a_late_shop";"A-10A Warthog (1978)";;
-"a_10a_late_0";"Fairchild Republic A-10A Warthog (1978)";;
+"a_10a_late_0";"Fairchild Republic | A-10A Warthog (1978)";;
 "a_10a_late_1";"A-10A Warthog (1978)";;
 "a_10a_late_2";"A-10A (1978)";;
 


### PR DESCRIPTION
v0.4.1d4-md3