### PR TITLE
renamed B-66B, MICA-EM, AH-64E (USA/GBR/JP/FR), F-11F nuke plane (USA/JP/ISR), AH-56A, removed type designations from bombs; changed file formats of syrup_units_cn, syrup_units_isr, syrup_units_jp, syrup_units_usa to play nicer with Edit CSV extension

### DIFF
--- a/Mod Files/syrup_units_cn.csv
+++ b/Mod Files/syrup_units_cn.csv
@@ -1,427 +1,419 @@
-"<ID|readonly|
-noverify>";"<English>";
-
-//RANK 1
-
+"<ID|readonly|noverify>";"<English>";;
+#had to change the format of the file to include a bunch of hashtags where spaces normally are so that using Edit CSV doesn't fuck up the file.
+#file formats are gonna be a little jank until i get into each one to fix them up. sorry, addy. -maple (11/13/2025)
+#RANK 1
 "gladiator_mk1_china_shop";"☀Gladiator Mk.I";;
 "gladiator_mk1_china_0";"☀Gloster Aircraft Company | Gladiator Mk. I ""Gé Jī""";;
 "gladiator_mk1_china_1";"☀Gladiator Mk.I";;
 "gladiator_mk1_china_2";"☀Gladiator Mk.I";;
-
+#
 "ki-27_otsu_china_shop";"☀Ki 27 Yi";;
 "ki-27_otsu_china_0";"☀Nakajima Aircraft | Ki 27 Yi | Type 97 Fighter Yi";;
 "ki-27_otsu_china_1";"☀Ki 27 Yi";;
 "ki-27_otsu_china_2";"☀Ki 27 Yi";;
-
+#
 "ki_43_3_ko_shop";"☀Ki 43-III Jia";;
 "ki_43_3_ko_0";"☀Nakajima Aircraft Company / Tachikawa Aircraft Company | Ki 43-III | Type 1 Fighter Model 3 Jia";;
 "ki_43_3_ko_1";"☀Ki 43-III Jia";;
 "ki_43_3_ko_2";"☀Ki 43-III Jia";;
-
+#
 "cw_21_shop";"☀C.W.21";;
 "cw_21_0";"☀Curtiss-Wright Corporation | C.W.21";;
 "cw_21_1";"☀C.W.21";;
 "cw_21_2";"☀C.W.21";;
-
+#
 "i-15bis_china_shop";"☀E-15bis Qishik";;
 "i-15bis_china_0";"☀TsKB-39 ""Polikarpov"" | E-15bis Qishik | I-15bis";;
 "i-15bis_china_1";"☀E-15bis Qishik";;
 "i-15bis_china_2";"☀E-15bis";;
-
+#
 "i-16_type5_1935_china_shop";"☀E-16-5 Ishak";;
 "i-16_type5_1935_china_0";"☀TsKB-39 ""Polikarpov"" | E-16-5 Ishak | I-16 Type 5";;
 "i-16_type5_1935_china_1";"☀E-16-5 Ishak";;
 "i-16_type5_1935_china_2";"☀E-16-5";;
-
+#
 "i-16_type10_china_shop";"☀E-16-10 Ishak";;
 "i-16_type10_china_0";"☀TsKB-39 ""Polikarpov"" | E-16-10 Ishak | I-16 Type 10";;
 "i-16_type10_china_1";"☀E-16-10 Ishak";;
 "i-16_type10_china_2";"☀E-16-10";;
-
+#
 "i-16_type17_china_shop";"☀E-16-17 Ishak";;
 "i-16_type17_china_0";"☀TsKB-39 ""Polikarpov"" | E-16-17 Ishak | I-16 Type 17";;
 "i-16_type17_china_1";"☀E-16-17 Ishak";;
 "i-16_type17_china_2";"☀E-16-17";;
-
+#
 "i-16_chung_28_shop";"☀Zhōng 28 Jia";;
 "i-16_chung_28_0";"☀TsKB-39 ""Polikarpov"" / Central Aircraft Manufacturing Company | Zhōng 28 Jia";;
 "i-16_chung_28_1";"☀Zhōng 28 Jia";;
 "i-16_chung_28_2";"☀Zhōng 28 Jia";;
-
+#
 "i-153_m62_china_shop";"☀E-153 Qishik";;
 "i-153_m62_china_0";"☀TsKB-39 ""Polikarpov"" | E-153 Qishik | I-153 Chaika (ASh-62)";;
 "i-153_m62_china_1";"☀E-153 Qishik";;
 "i-153_m62_china_2";"☀E-153";;
-
+#
 "v_11g_shop";"☀V-11-G";;
 "v_11g_0";"☀Vultee Aircraft | V-11-G";;
 "v_11g_1";"☀V-11-G";;
 "v_11g_2";"☀V-11-G";;
-
+#
 "v_12d_shop";"☀V-12-D";;
 "v_12d_0";"☀Vultee Aircraft | V-12-D";;
 "v_12d_1";"☀V-12-D";;
 "v_12d_2";"☀V-12-D";;
-
+#
 "hs-123a-1_china_shop";"☀Hs 123 A-1 Héng Jī";;
 "hs-123a-1_china_0";"☀Henschel Flugzeug-Werke | Hs 123 A-1 Héng Jī";;
 "hs-123a-1_china_1";"☀Hs 123 A-1 Héng Jī";;
 "hs-123a-1_china_2";"☀Hs 123 A-1";;
-
+#
 "martin_139wc_shop";"☀Martin 139WC";;
 "martin_139wc_0";"☀Glenn L. Martin Company | Martin Model 139WC";;
 "martin_139wc_1";"☀Martin 139WC";;
 "martin_139wc_2";"☀Martin 139WC";;
-
+#
 "hawk_iii_shop";"☀Hawk III";;
 "hawk_iii_0";"☀Curtiss-Wright Corporation | Hawk III";;
 "hawk_iii_1";"☀Hawk III";;
 "hawk_iii_2";"☀Hawk III";;
-
+#
 "d_510c_shop";"☀D.510C Dì Jī";;
 "d_510c_0";"☀Constructions Aéronautiques Émile Dewoitine | D.510C Dì Jī";;
 "d_510c_1";"☀D.510C Dì Jī";;
 "d_510c_2";"☀D.510C";;
-
-//RANK 2
-
+#
+#RANK 2
 "p-66_shop";"☀P-48-C Vanguard";;
 "p-66_0";"☀Vultee Aircraft | P-48-C Vanguard | P-66 Vanguard";;
 "p-66_1";"☀P-48-C Vanguard";;
 "p-66_2";"☀P-48-C";;
-
+#
 "p-40e_china_shop";"☀P-40E Kittyhawk";;
 "p-40e_china_0";"☀Curtiss-Wright Corporation | P-40E Kittyhawk";;
 "p-40e_china_1";"☀P-40E Kittyhawk";;
 "p-40e_china_2";"☀P-40E";;
-
+#
 "p-43a-1_china_shop";"☀P-43A-1 Lancer";;
 "p-43a-1_china_0";"☀Republic Aviation Corporation | P-43A-1 Lancer | Block 1";;
 "p-43a-1_china_1";"☀P-43A-1 Lancer";;
 "p-43a-1_china_2";"☀P-43A-1";;
-
+#
 "a_29_hudson_shop";"☀A-29 Hudson";;
 "a_29_hudson_0";"☀Lockheed Corporation | A-29 Hudson";;
 "a_29_hudson_1";"☀A-29 Hudson";;
 "a_29_hudson_2";"☀A-29";;
-
+#
 "db_3a_china_shop";"☀D.B.3";;
 "db_3a_china_0";"☀OKB-39 ""Ilyushin"" | D.B.3 | DB-3A";;
 "db_3a_china_1";"☀D.B.3";;
 "db_3a_china_2";"☀D.B.3";;
-
+#
 "sb_2m_103u_china_shop";"☀C.B. (M-103U)";;
 "sb_2m_103u_china_0";"☀OKB-156 ""Tupolev"" | C.B. (M-103U) | SB (M-103U)";;
 "sb_2m_103u_china_1";"☀C.B. (M-103U)";;
 "sb_2m_103u_china_2";"☀C.B. (M-103U)";;
-
+#
 "p1y1_mod11_china_shop";"☀P1Y1 Ginga";;
 "p1y1_mod11_china_0";"☀Nakajima Aircraft Company | P1Y1 Ginga | Model 11";;
 "p1y1_mod11_china_1";"☀P1Y1 Ginga";;
 "p1y1_mod11_china_2";"☀P1Y1";;
-
+#
 "p-40c_china_shop";"☀Hawk 81A-3";;
 "p-40c_china_0";"☀Curtiss-Wright Corporation | Hawk Model 81A-3";;
 "p-40c_china_1";"☀Hawk 81A-3";;
 "p-40c_china_2";"☀Hawk 81A-3";;
-
+#
 "ki-45_hei_tei_china_shop";"␗Ki 45 Gai Bing";;
 "ki-45_hei_tei_china_0";"␗Kawasaki Aircraft Company | Ki 45 Gai Bing | Type 2 Twin-Seat Fighter | Model 3 Bing | Dīng Equipment";;
 "ki-45_hei_tei_china_1";"␗Ki 45 Gai Bing (Dīng)";;
 "ki-45_hei_tei_china_2";"␗Ki 45 Gai Bing (Dīng)";;
-
-//RANK 3
-
+#
+#RANK 3
 "p-47d_23_ra_china_rocaf_shop";"☀P-47D-23 Thunderbolt";;
 "p-47d_23_ra_china_rocaf_0";"☀Republic Aviation Corporation | P-47D-23 Thunderbolt | Block 23";;
 "p-47d_23_ra_china_rocaf_1";"☀P-47D-23 Thunderbolt";;
 "p-47d_23_ra_china_rocaf_2";"☀P-47D-23";;
-
+#
 "p-47d_30_china_shop";"☀F-47D-30 Thunderbolt";;
 "p-47d_30_china_0";"☀Republic Aviation Corporatio | F-47D-30 Thunderbolt | Block 30";;
 "p-47d_30_china_1";"☀F-47D-30 Thunderbolt";;
 "p-47d_30_china_2";"☀F-47D-30";;
-
+#
 "f_47n_25_re_china_shop";"☀F-47N-25 Thunderbolt";;
 "f_47n_25_re_china_0";"☀Republic Aviation Corporation | F-47N-25 Thunderbolt | Block 25";;
 "f_47n_25_re_china_1";"☀F-47N-25 Thunderbolt";;
 "f_47n_25_re_china_2";"☀F-47N-25";;
-
+#
 "p-51c-11-nt_china_shop";"☀P-51C-11 Yema Jī";;
 "p-51c-11-nt_china_0";"☀North American Aviation | P-51C-11 Mustang ""Yema Jī"" | Block 11";;
 "p-51c-11-nt_china_1";"☀P-51C-11 Yema Jī";;
 "p-51c-11-nt_china_2";"☀P-51C-11";;
-
+#
 "p-51d-20_china_shop";"☀F-51D-20 Yema Jī";;
 "p-51d-20_china_0";"☀North American Aviation | F-51D-20 Mustang ""Yema Jī"" | Block 20";;
 "p-51d-20_china_1";"☀F-51D-20 Yema Jī";;
 "p-51d-20_china_2";"☀F-51D-20";;
-
+#
 "p-51k_shop";"☀F-51K-15 Yema Jī";;
 "p-51k_0";"☀North American Aviation | F-51K-15 Mustang ""Yema Jī"" | Block 15";;
 "p-51k_1";"☀F-51K-15 Yema Jī";;
 "p-51k_2";"☀F-51K-15";;
-
+#
 "ki_44_2_hei_china_shop";"☀Ki 44-II Bing";;
 "ki_44_2_hei_china_0";"☀Nakajima Aircraft Company | Ki 44-II ""Zhōngkuí"" | Type 2 Fighter | Model 2 Bing";;
 "ki_44_2_hei_china_1";"☀Ki 44-II Bing";;
 "ki_44_2_hei_china_2";"☀Ki 44-II Bing";;
-
+#
 "ki_61_1a_otsu_china_shop";"☀Ki 61-I Yi";;
 "ki_61_1a_otsu_china_0";"☀Kawasaki Aircraft Company | Ki 61-I ""Fēiyàn"" | Type 3 Fighter | Model 1 Yi";;
 "ki_61_1a_otsu_china_1";"☀Ki 61-I Yi";;
 "ki_61_1a_otsu_china_2";"☀Ki 61-I Yi";;
-
+#
 "mosquito_fb_mk26_china_shop";"☀FB-26 Mosquito";;
 "mosquito_fb_mk26_china_0";"☀de Havilland Aircraft Company | Mosquito | Fighter/Bomber, Mk.26 | FB-26";;
 "mosquito_fb_mk26_china_1";"☀FB-26 Mosquito";;
 "mosquito_fb_mk26_china_2";"☀FB-26";;
-
+#
 "p-38l_1_china_rocaf_shop";"☀P-38L-1 Lightning";;
 "p-38l_1_china_rocaf_0";"☀Lockheed Corporation | P-38L-1 Lightning | Block 1";;
 "p-38l_1_china_rocaf_1";"☀P-38L-1 Lightning";;
 "p-38l_1_china_rocaf_2";"☀P-38L-1";;
-
+#
 "b_25j_30_china_shop";"☀B-25J-30 Mitchell";;
 "b_25j_30_china_0";"☀North American Aviation | B-25J-30 Mitchell | Block 30";;
 "b_25j_30_china_1";"☀B-25J-30 Mitchell";;
 "b_25j_30_china_2";"☀B-25J-30";;
-
+#
 "a6m2_zero_china_shop";"☀A6M2 Líng";;
 "a6m2_zero_china_0";"☀Mitsubishi Heavy Industries | A6M2 ""Líng"" | Type 0 Fighter ""Zero""| Model 21";;
 "a6m2_zero_china_1";"☀A6M2 Líng";;
 "a6m2_zero_china_2";"☀A6M2";;
-
-//RANK 4
-
+#
+#RANK 4
 "la-11_china_shop";"␗La-11 Fang";;
 "la-11_china_0";"␗OKB-301 ""Lavochkin"" | La-11 Fang";;
 "la-11_china_1";"␗La-11 Fang";;
 "la-11_china_2";"␗La-11";;
-
+#
 "la-9_china_shop";"␗La-9 Fritz";;
 "la-9_china_0";"␗OKB-301 ""Lavochkin"" | La-9 Fritz";;
 "la-9_china_1";"␗La-9 Fritz";;
 "la-9_china_2";"␗La-9";;
-
+#
 "il-10_1946_china_shop";"␗Il-10 Beast (1947)";;
 "il-10_1946_china_0";"␗OKB-39 ""Ilyushin"" | Il-10 Beast (1947)";;
 "il-10_1946_china_1";"␗Il-10 Beast (1947)";;
 "il-10_1946_china_2";"␗Il-10 (1947)";;
-
+#
 "pb4y-2_china_shop";"☀P4Y-2 Privateer";;
 "pb4y-2_china_0";"☀Consolidated Aircraft Corporation | P4Y-2 Privateer";;
 "pb4y-2_china_1";"☀P4Y-2 Privateer";;
 "pb4y-2_china_2";"☀P4Y-2";;
-
+#
 "tu-2_postwar_china_shop";"␗Tu-2S-44 Bat";;
 "tu-2_postwar_china_0";"␗OKB-156 ""Tupolev"" | Tu-2S Bat | Series 44";;
 "tu-2_postwar_china_1";"␗Tu-2S-44 Bat";;
 "tu-2_postwar_china_2";"␗Tu-2S-44";;
-
+#
 "ki_84_ko_china_shop";"☀Ki 84-I Jia";;
 "ki_84_ko_china_0";"☀Nakajima Aircraft Company | Ki 84-I Jia ""Jífēng"" | Type 4 Fighter | Model 1 Jia";;
 "ki_84_ko_china_1";"☀Ki 84-I Jia";;
 "ki_84_ko_china_2";"☀Ki 84-I Jia";;
-
-//RANK 5
-
+#
+#RANK 5
 "f-86f-30_china_shop";"☀F-86F-30 Sabre";;
 "f-86f-30_china_0";"☀North American Aviation | F-86F-30 Sabre | Block 30";;
 "f-86f-30_china_1";"☀F-86F-30 Sabre";;
 "f-86f-30_china_2";"☀F-86F-30";;
-
+#
 "f-86f-40_china_shop";"☀F-86F-40 Sabre";;
 "f-86f-40_china_0";"☀North American Aviation | F-86F-40 Sabre | Block 40";;
 "f-86f-40_china_1";"☀F-86F-40 Sabre";;
 "f-86f-40_china_2";"☀F-86F-40";;
-
+#
 "mig-9_china_shop";"␗MiG-9 Fargo";;
 "mig-9_china_0";"␗OKB-155 ""Mikoyan i Gurevich"" | MiG-9 Fargo";;
 "mig-9_china_1";"␗MiG-9 Fargo";;
 "mig-9_china_2";"␗MiG-9";;
-
+#
 "mig-9_late_china_shop";"␗I-307";;
 "mig-9_late_china_0";"␗OKB-155 ""Mikoyan i Gurevich"" | I-307 | Late-Model MiG-9 Prototype (1948)";;
 "mig-9_late_china_1";"␗I-307";;
 "mig-9_late_china_2";"␗I-307";;
-
+#
 "mig-15bis_nr23_china_shop";"␗J-2 Fagot-B";;
 "mig-15bis_nr23_china_0";"␗Shenyang Aircraft Corporation | J-2 Fagot-B";;
 "mig-15bis_nr23_china_1";"␗J-2 Fagot-B";;
 "mig-15bis_nr23_china_2";"␗J-2";;
-
+#
 "mig-17_china_shop";"␗J-4 Fresco-C";;
 "mig-17_china_0";"␗Shenyang Aircraft Corporation | J-4 Fresco-C";;
 "mig-17_china_1";"␗J-4 Fresco-C";;
 "mig-17_china_2";"␗J-4";;
-
+#
 "f-84g_china_shop";"☀F-84G-21 Thunderjet";;
 "f-84g_china_0";"☀Republic Aviation Corporation | F-84G-21 Thunderjet | Block 21";;
 "f-84g_china_1";"☀F-84G-21 Thunderjet";;
 "f-84g_china_2";"☀F-84G-21";;
-
+#
 "f-84g-31-re_china_shop";"☀F-84G-31 Thunderjet";;
 "f-84g-31-re_china_0";"☀Republic Aviation Corporation | F-84G-31 Thunderjet | Block 31";;
 "f-84g-31-re_china_1";"☀F-84G-31 Thunderjet";;
 "f-84g-31-re_china_2";"☀F-84G-31";;
-
+#
 "tu_4_china_shop";"␗Tu-4 Bull";;
 "tu_4_china_0";"␗OKB-156 ""Tupolev"" | Tu-4 Bull";;
 "tu_4_china_1";"␗Tu-4 Bull";;
 "tu_4_china_2";"␗Tu-4";;
-
+#
 "il_28_china_shop";"␗Il-28 Beagle";;
 "il_28_china_0";"␗OKB-39 ""Ilyushin"" | Il-28 Beagle";;
 "il_28_china_1";"␗Il-28 Beagle";;
 "il_28_china_2";"␗Il-28";;
-
+#
 "mig-17_f5_shop";"␗F-5 Fresco-C";;
 "mig-17_f5_0";"␗Shenyang Aircraft Corporation | F-5 Fresco-C";;
 "mig-17_f5_1";"␗F-5 Fresco-C";;
 "mig-17_f5_2";"␗F-5";;
-
-//RANK 6
-
+#
+#RANK 6
 "f-100a_china_shop";"☀F-100A-16 Super Sabre";;
 "f-100a_china_0";"☀North American Aviation | F-100A-16 Super Sabre | Block 16";;
 "f-100a_china_1";"☀F-100A-16 Super Sabre";;
 "f-100a_china_2";"☀F-100A-16";;
-
+#
 "f_100f_china_shop";"☀F-100F-6 Super Sabre";;
 "f_100f_china_0";"☀North American Aviation | F-100F-6 Super Sabre | Block 6";;
 "f_100f_china_1";"☀F-100F-6 Super Sabre";;
 "f_100f_china_2";"☀F-100F-6";;
-
+#
 "f-104a_china_shop";"☀F-104A-25 Starfighter ";;
 "f-104a_china_0";"☀Lockheed Corporation | F-104A-25 Starfighter | Block 25";;
 "f-104a_china_1";"☀F-104A-25 Starfighter";;
 "f-104a_china_2";"☀F-104A-25";;
-
+#
 "f-104g_china_shop";"☀F-104G-10 Starfighter";;
 "f-104g_china_0";"☀Lockheed Corporation | F-104G-10 Starfighter | Block 10";;
 "f-104g_china_1";"☀F-104G-10 Starfighter";;
 "f-104g_china_2";"☀F-104G-10";;
-
+#
 "mig-19j_6a_shop";"␗J-6A Farmer-C";;
 "mig-19j_6a_0";"␗Shenyang Aircraft Corporation | J-6A Farmer-C";;
 "mig-19j_6a_1";"␗J-6A Farmer-C";;
 "mig-19j_6a_2";"␗J-6A";;
-
+#
 "j_7_mk2_shop";"␗J-7II Fishcan";;
 "j_7_mk2_0";"␗Chengdu Aircraft Corporation | J-7II Fishcan";;
 "j_7_mk2_1";"␗J-7II Fishcan";;
 "j_7_mk2_2";"␗J-7II";;
-
+#
 "j_7e_shop";"␗J-7E Fishcan-D";;
 "j_7e_0";"␗Chengdu Aircraft Corporation | J-7E Fishcan-D";;
 "j_7e_1";"␗J-7E Fishcan-D";;
 "j_7e_2";"␗J-7E";;
-
+#
 "j_7d_shop";"␗J-7D Fishcan-E";;
 "j_7d_0";"␗Chengdu Aircraft Corporation | J-7D Fischan-E";;
 "j_7d_1";"␗J-7D Fishcan-E";;
 "j_7d_2";"␗J-7D";;
-
+#
 "q_5_early_shop";"Q-5 Fantan";;
 "q_5_early_0";"Nanchang Aircraft Manufacturing Corporation | Q-5 Fantan (1969)";;
 "q_5_early_1";"Q-5 Fantan";;
 "q_5_early_2";"Q-5";;
-
+#
 "q_5a_shop";"Q-5A Fantan";;
 "q_5a_0";"Nanchang Aircraft Manufacturing Corporation | Q-5A Fantan";;
 "q_5a_1";"Q-5A Fantan";;
 "q_5a_2";"Q-5A";;
-
+#
 "q_5l_shop";"Q-5L Fantan";;
 "q_5l_0";"Nanchang Aircraft Manufacturing Corporation | Q-5L Fantan";;
 "q_5l_1";"Q-5L Fantan";;
 "q_5l_2";"Q-5L";;
-
-//RANK 7
-
+#
+#RANK 7
 "f-5a_china_shop";"☀F-5A-25 Freedom Fighter";;
 "f-5a_china_0";"☀Northrop Corporation | F-5A-25 Freedom Fighter | Block 25";;
 "f-5a_china_1";"☀F-5A-25 Freedom Fighter";;
 "f-5a_china_2";"☀F-5A-25";;
-
+#
 "f-5e_aidc_shop";"☀F-5E Chung Cheng";;
 "f-5e_aidc_0";"☀Aerospace Industrial Development Corporation (AIDC) | F-5E Chung Cheng";;
 "f-5e_aidc_1";"☀F-5E Chung Cheng";;
 "f-5e_aidc_2";"☀F-5E";;
-
+#
 "j_8b_shop";"J-8B Finback";;
 "j_8b_0";"Shenyang Aircraft Corporation | J-8B Finback";;
 "j_8b_1";"J-8B Finback";;
 "j_8b_2";"J-8B";;
-
+#
 "j_8f_shop";"J-8F Finback";;
 "j_8f_0";"Shenyang Aircraft Corporation | J-8F Finback";;
 "j_8f_1";"J-8F Finback";;
 "j_8f_2";"J-8F";;
-
+#
 "j_8f_missile_test_shop";"J-8F Finback";;
 "j_8f_missile_test_0";"Shenyang Aircraft Corporation | J-8F Finback";;
 "j_8f_missile_test_1";"J-8F Finback";;
 "j_8f_missile_test_2";"J-8F";;
-
+#
 "a_5c_shop";"☪A-5C Fantan";;
 "a_5c_0";"☪Nanchang Aircraft Manufacturing Corporation | A-5C Fantan";;
 "a_5c_1";"☪A-5C Fantan";;
 "a_5c_2";"☪A-5C";;
-
-//RANK 8
-
+#
+#RANK 8
 "f_16a_block_20_mlu_shop";"☀F-16A-20 Viper";;
 "f_16a_block_20_mlu_0";"☀General Dynamics Corporation | F-16A-20 Viper | Block 20";;
 "f_16a_block_20_mlu_1";"☀F-16A-20 Viper";;
 "f_16a_block_20_mlu_2";"☀F-16A-20";;
-
+#
 "j_10a_shop";"J-10A Měnglóng";;
 "j_10a_0";"Chengdu Aircraft Corporation (CAC) | J-10A Měnglóng (Vigorous Dragon)";;
 "j_10a_1";"J-10A Měnglóng";;
 "j_10a_2";"J-10A";;
-
+#
 "mirage_2000_5ei_shop";"☀Mirage 2000-5Ei";;
 "mirage_2000_5ei_0";"☀Dassault Aviation SA | Mirage 2000-5Ei";;
 "mirage_2000_5ei_1";"☀Mirage 2000-5Ei";;
 "mirage_2000_5ei_2";"☀Mirage 2000-5Ei";;
-
+#
 "j_11_shop";"␗J-11 Flanker-B+";;
 "j_11_0";"␗Shenyang Aircraft Corporation | J-11 Flanker-B+ | Su-27SK (2000)";;
 "j_11_1";"␗J-11 Flanker-B+";;
 "j_11_2";"␗J-11";;
-
+#
 "j_11a_shop";"␗J-11A MLU Flanker-B+";;
 "j_11a_0";"␗Shenyang Aircraft Corporation | J-11A Flanker-B+ | Su-27SK | Mid-Life Update (2015)";;
 "j_11a_1";"␗J-11A MLU Flanker-B+";;
 "j_11a_2";"␗J-11A MLU";;
-
+#
 "j_11b_shop";"␗J-11B Flanker-L";;
 "j_11b_0";"␗Shenyang Aircraft Corporation | J-11B Flanker-L";;
 "j_11b_1";"␗J-11B Flanker-L";;
 "j_11b_2";"␗J-11B";;
-
+#
 "jh_7a_shop";"JH-7A Fēi Bào";;
 "jh_7a_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard)";;
 "jh_7a_1";"JH-7A Fēi Bào";;
 "jh_7a_2";"JH-7A";;
-
+#
 "jf_17_shop";"JF-17A Thunder";;
 "jf_17_0";"Chengdu Aircraft Corporation (CAC) / Pakistan Aeronautical Complex (PAC) | JF-17A Thunder | Block 1";;
 "jf_17_1";"JF-17A Thunder";;
 "jf_17_2";"JF-17A";;
-
+#
 "jh_7_shop";"JH-7 Fēi Bào";;
 "jh_7_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7 Fēi Bào (Flying Leopard) | Block 02";;
 "jh_7_1";"JH-7 Fēi Bào";;
 "jh_7_2";"JH-7";;
-
+#
 "jh_7a_prototype_shop";"JH-7A Fēi Bào (811)";;
 "jh_7a_prototype_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard) | Prototype 811";;
 "jh_7a_prototype_1";"JH-7A Fēi Bào (811)";;
 "jh_7a_prototype_2";"JH-7A (811)";;
-
+#
 "shop/group/ki_27_group";"☀Ki 27/Ki 43";;
 "shop/group/i-16_china_group";"Zhōng 28/☀E-16";;
 "shop/group/p_40_china_group";"☀P-40 Kittyhawk/P-43 Lancer";;
@@ -434,3 +426,10 @@ noverify>";"<English>";
 "shop/group/mig-19_china_group";"␗J-6 Farmer/J-7 Fishcan";;
 "shop/group/f_5a_china_group";"☀F-5A/E";;
 "shop/group/j_11_group";"␗J-11 Flanker-B+";;
+#
+#helicopters
+#RANK 7
+"ah_64e_china_shop";"☀AH-64E Guardian Apache (v6)";;
+"ah_64e_china_0";"Boeing Defense, Space & Security | ☀Helicopter, Attack, AH-64E Guardian Apache | Capability Version 6";;
+"ah_64e_china_1";"☀AH-64E Guardian Apache (v6)";;
+"ah_64e_china_2";"☀AH-64E (v6)";;

--- a/Mod Files/syrup_units_fr.csv
+++ b/Mod Files/syrup_units_fr.csv
@@ -1,531 +1,530 @@
-"<ID|readonly|
-noverify>";"<English>";
-
+"<ID|readonly|noverify>";"<English>";;
+#
 "md_450b_barougan_shop";"Barougan";;
 "md_450b_barougan_0";"Société des Avions Marcel Dassault | M.D.450B Barougan";;
 "md_450b_barougan_1";"Barougan";;
 "md_450b_barougan_2";"Barougan";;
-
+#
 "md_450b_ouragan_shop";"Ouragan";;
 "md_450b_ouragan_0";"Société des Avions Marcel Dassault | M.D.450B Ouragan";;
 "md_450b_ouragan_1";"Ouragan";;
 "md_450b_ouragan_2";"Ouragan";;
-
+#
 "lancaster_mr7_france_shop";"▄Lancaster Mk.VII WU";;
 "lancaster_mr7_france_0";"A.V. Roe and Company  | ▄Lancaster | Medium-Range Bomber, Mk.VII Western Union";;
 "lancaster_mr7_france_1";"▄Lancaster Mk.VII WU";;
 "lancaster_mr7_france_2";"▄Lancaster Mk.VII WU";;
-
+#
 "so_8000_narval_shop";"S.O.8000 Narval";;
 "so_8000_narval_0";"Société Nationale des Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.8000 Narval  | 1949 Prototype";;
 "so_8000_narval_1";"S.O.8000 Narval";;
 "so_8000_narval_2";"S.O.8000";;
-
+#
 "vb_10_02_shop";"VB.10-02";;
 "vb_10_02_0";"Arsenal de l'Aéronautique | VB.10-02 | Second Prototype (1946)";;
 "vb_10_02_1";"VB.10-02";;
 "vb_10_02_2";"VB.10-02";;
-
+#
 "vb_10c1_shop";"VB.10C-01";;
 "vb_10c1_0";"Arsenal de l'Aéronautique | VB.10C-01 | First Prototype (1945)";;
 "vb_10c1_1";"VB.10C-01";;
 "vb_10c1_2";"VB.10C-01";;
-
+#
 "mb_157_shop";"M.B.157";;
 "mb_157_0";"Société Nationale des Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | M.B.157 | 1942 Prototype";;
 "mb_157_1";"M.B.157";;
 "mb_157_2";"M.B.157";;
-
+#
 "mb_162_shop";"M.B.162.01";;
 "mb_162_0";"Société Nationale des Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | M.B.162.01 | 1940 Prototype";;
 "mb_162_1";"M.B.162.01";;
 "mb_162_2";"M.B.162.01";;
-
+#
 "firefly_mk4_netherlands_shop";"◘Firefly Mk.IV";;
 "firefly_mk4_netherlands_0";"Fairey Aviation Company, Ltd. | ◘Firefly | Fighter, Mk.IV";;
 "firefly_mk4_netherlands_1";"◘Firefly Mk.IV";;
 "firefly_mk4_netherlands_2";"◘Firefly Mk.IV";;
-
+#
 "yak-9t_france_shop";"▄Yak-9T [Challe]";;
 "yak-9t_france_0";"OKB-115 ""Yakovlev"" | ▄Challe's Yak-9T";;
 "yak-9t_france_1";"▄Yak-9T [Challe]";;
 "yak-9t_france_2";"▄Yak-9T [Challe]";;
-
+#
 "yak-3_france_shop";"▄Yak-3 (1944)";;
 "yak-3_france_0";"OKB-115 ""Yakovlev"" | ▄Yak-3 (1944)";;
 "yak-3_france_1";"▄Yak-3 (1944)";;
 "yak-3_france_2";"▄Yak-3 (1944)";;
-
+#
 "vg_33_shop";"V.G.33C-1";;
 "vg_33_0";"Arsenal de l'Aéronautique | V.G.33C-1 (1939)";;
 "vg_33_1";"V.G.33C-1";;
 "vg_33_2";"V.G.33C-1";;
-
+#
 "d_520_france_shop";"D.520";;
 "d_520_france_0";"Société Nationale des Constructions Aéronautiques du Midi (SNCAM) / Société Nationale des Constructions Aéronautiques du Sud-Estu Center (SNCASE) | Dewoitine D.520 ";;
 "d_520_france_1";"D.520";;
 "d_520_france_2";"D.520";;
-
+#
 "ms_410c1_shop";"M.S.410";;
 "ms_410c1_0";"Aéroplanes Morane-Saulnier | M.S.410";;
 "ms_410c1_1";"M.S.410";;
 "ms_410c1_2";"M.S.410";;
-
+#
 "potez_630_shop";"Potez 630";;
 "potez_630_0";"Société Nationale des Constructions Aéronautiques du Nord (SNCAN) | Potez 630";;
 "potez_630_1";"Potez 630";;
 "potez_630_2";"Potez 630";;
-
+#
 "potez_631_shop";"Potez 631";;
 "potez_631_0";"Société Nationale des Constructions Aéronautiques du Nord (SNCAN) | Potez 631";;
 "potez_631_1";"Potez 631";;
 "potez_631_2";"Potez 631";;
-
+#
 "a-35b_shop";"▄A-35B Vengenace ";;
 "a-35b_0";"Vultee Aircraft, Inc. | ▄A-35B Vengeance";;
 "a-35b_1";"▄A-35B Vengenace ";;
 "a-35b_2";"▄A-35B";;
-
+#
 "mb_175t_shop";"M.B.175T";;
 "mb_175t_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | M.B 175T";;
 "mb_175t_1";"M.B.175T";;
 "mb_175t_2";"M.B.175T";;
-
+#
 "nc_223_3_shop";"N.C.223.3";;
 "nc_223_3_0";"Societe Nationale de Constructions Aeronautiques du Center (SNCAC) | N.C.223.3";;
 "nc_223_3_1";"N.C.223.3";;
 "nc_223_3_2";"N.C.223.3";;
-
+#
 "leo_451_late_shop";"LeO 451 (1939)";;
 "leo_451_late_0";"Société Nationale des Constructions Aéronautiques du Sud-Estu Center (SNCASE) / Société Nationale des Constructions Aéronautiques de l'Ouest (SNCAO) | LeO 451 (1939)";;
 "leo_451_late_1";"LeO 451 (1939)";;
 "leo_451_late_2";"LeO 451 (1939)";;
-
+#
 "leo_451_early_shop";"LeO 451 (1937)";;
 "leo_451_early_0";"Société Nationale des Constructions Aéronautiques du Sud-Estu Center (SNCASE) / Société Nationale des Constructions Aéronautiques de l'Ouest (SNCAO) | LeO 451 (1937)";;
 "leo_451_early_1";"LeO 451 (1937)";;
 "leo_451_early_2";"LeO 451 (1937)";;
-
+#
 "fokker_g1a_shop";"◗Fokker G.IA";;
 "fokker_g1a_0";"N.V. Koninklijke Nederlandse Vliegtuigenfabriek Fokker | ◗G.IA Mercury";;
 "fokker_g1a_1";"◗Fokker G.IA";;
 "fokker_g1a_2";"◗Fokker G.IA";;
-
+#
 "mb_152c1_shop";"M.B.152C1";;
 "mb_152c1_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | M.B.152C1";;
 "mb_152c1_1";"M.B.152C1";;
 "mb_152c1_2";"M.B.152C1";;
-
+#
 "ms_405c1_shop";"M.S.405C1";;
 "ms_405c1_0";"Aéroplanes Morane-Saulnier | M.S.405C1";;
 "ms_405c1_1";"M.S.405C1";;
 "ms_405c1_2";"M.S.405C1";;
-
+#
 "ms_406c1_shop";"M.S.406C1";;
 "ms_406c1_0";"Aéroplanes Morane-Saulnier | M.S.406C1";;
 "ms_406c1_1";"M.S.406C1";;
 "ms_406c1_2";"M.S.406C1";;
-
+#
 "caudron_cr714_shop";"C.R.714";;
 "caudron_cr714_0";"Société des Avions Caudron | C.R.714";;
 "caudron_cr714_1";"C.R.714";;
 "caudron_cr714_2";"C.R.714";;
-
+#
 "d_371_shop";"D.371";;
 "d_371_0";"Constructions Aéronautiques Émile Dewoitine | D.371";;
 "d_371_1";"D.371";;
 "d_371_2";"D.371";;
-
+#
 "d_373_shop";"D.373";;
 "d_373_0";"Constructions Aéronautiques Émile Dewoitine | D.373";;
 "d_373_1";"D.373";;
 "d_373_2";"D.373";;
-
+#
 "h-75a-1_france_shop";"▄H-75A-1";;
 "h-75a-1_france_0";"Curtiss-Wright Corporation | ▄Hawk Model 75A-1";;
 "h-75a-1_france_1";"▄H-75A-1";;
 "h-75a-1_france_2";"▄H-75A-1";;
-
+#
 "h-75a-4_france_shop";"▄H-75A-4";;
 "h-75a-4_france_0";"Curtiss-Wright Corporation | ▄Hawk Model 75A-4";;
 "h-75a-4_france_1";"▄H-75A-4";;
 "h-75a-4_france_2";"▄H-75A-4";;
-
+#
 "br_693_ab2_shop";"Br.693AB2";;
 "br_693_ab2_0";"Société Nationale de Constructions Aéronautiques du Centre (SNCAC) | Br.693AB2";;
 "br_693_ab2_1";"Br.693AB2";;
 "br_693_ab2_2";"Br.693AB2";;
-
+#
 "v_156_f_shop";"▄V-156-F Vindicator";;
 "v_156_f_0";"Chance Vought Corporation | ▄V-156-F Vindicator";;
 "v_156_f_1";"▄V-156-F Vindicator";;
 "v_156_f_2";"▄V-156-F";;
-
+#
 "maryland_mk1_france_shop";"▄Martin 167-A3";;
 "maryland_mk1_france_0";"Glenn L. Martin Company | ▄Martin 167-A3";;
 "maryland_mk1_france_1";"▄Martin 167-A3";;
 "maryland_mk1_france_2";"▄Martin 167-A3";;
-
+#
 "mb_174_a3_shop";"M.B.174A-3";;
 "mb_174_a3_0";"Société des Avions Marcel Bloch | M.B.174A-3";;
 "mb_174_a3_1";"M.B.174A-3";;
 "mb_174_a3_2";"M.B.174A-3";;
-
+#
 "f_222_2_shop";"F.222.2";;
 "f_222_2_0";"Farman Aviation Works | F.222.2";;
 "f_222_2_1";"F.222.2";;
 "f_222_2_2";"F.222.2";;
-
+#
 "fokker_d21_netherlands_shop";"◗Fokker D.XXI-2";;
 "fokker_d21_netherlands_0";"N.V. Koninklijke Nederlandse Vliegtuigenfabriek Fokker | ◗D.XXI-2";;
 "fokker_d21_netherlands_1";"◗Fokker D.XXI-2";;
 "fokker_d21_netherlands_2";"◗Fokker D.XXI-2";;
-
+#
 "gladiator_mk1_belgium_shop";"▄Gladiator Mk.I";;
 "gladiator_mk1_belgium_0";"Gloster Aircraft Company | ▄Gladiator | Mk.I";;
 "gladiator_mk1_belgium_1";"▄Gladiator Mk.I";;
 "gladiator_mk1_belgium_2";"▄Gladiator Mk.I";;
-
+#
 "d_510_shop";"D.510 [Pallier]";;
 "d_510_0";"Constructions Aéronautiques Émile Dewoitine | Pallier's D.510";;
 "d_510_1";"D.510 [Pallier]";;
 "d_510_2";"D.510 [Pallier]";;
-
+#
 "mb_151c1_shop";"M.B.151C.1";;
 "mb_151c1_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | M.B.151C.1";;
 "mb_151c1_1";"M.B.151C.1";;
 "mb_151c1_2";"M.B.151C.1";;
-
+#
 "d_500_shop";"D.500";;
 "d_500_0";"Constructions Aéronautiques Émile Dewoitine | D.500";;
 "d_500_1";"D.500";;
 "d_500_2";"D.500";;
-
+#
 "d_501_shop";"D.501";;
 "d_501_0";"Constructions Aéronautiques Émile Dewoitine | D.501";;
 "d_501_1";"D.501";;
 "d_501_2";"D.501";;
-
+#
 "pby-5a_late_france_shop";"⚜PBY-5A Catalina (1941)";;
 "pby-5a_late_france_0";"Consolidated Aircraft Corporation | ⚜PBY-5A Catalina (1941)";;
 "pby-5a_late_france_1";"⚜PBY-5A Catalina (1941)";;
 "pby-5a_late_france_2";"⚜PBY-5A (1941)";;
-
+#
 "p-40f-5_france_ep_shop";"⚜P-40F-5 Lafayette";;
 "p-40f-5_france_ep_0";"Curtiss-Wright Corporation | ⚜P-40F-5 Lafayette | Block 5";;
 "p-40f-5_france_ep_1";"⚜P-40F-5 Lafayette";;
 "p-40f-5_france_ep_2";"⚜P-40F-5";;
-
+#
 "sbd-5_france_shop";"⚜SBD-5 Dauntless";;
 "sbd-5_france_0";"Curtiss-Wright Corporation | ⚜SBD-5 Dauntless";;
 "sbd-5_france_1";"⚜SBD-5 Dauntless";;
 "sbd-5_france_2";"⚜SBD-5";;
-
+#
 "f6f-5_france_shop";"⚜F6F-5 Hellcat";;
 "f6f-5_france_0";"Grumman Aircraft Engineering Corporation | ⚜F6F-5 Hellcat";;
 "f6f-5_france_1";"⚜F6F-5 Hellcat";;
 "f6f-5_france_2";"⚜F6F-5";;
-
+#
 "sb2c_5_france_shop";"⚜SB2C-5 Helldiver";;
 "sb2c_5_france_0";"Curtiss-Wright Corporation | ⚜SB2C-5 Helldiver | Block 5";;
 "sb2c_5_france_1";"⚜SB2C-5 Helldiver";;
 "sb2c_5_france_2";"⚜SB2C-5";;
-
+#
 "p-47d_22_re_france_shop";"⚜P-47D-22 Thunderbolt";;
 "p-47d_22_re_france_0";"Republic Aviation Corporation | ⚜P-47D-22 Thunderbolt | Block 22";;
 "p-47d_22_re_france_1";"⚜P-47D-22 Thunderbolt";;
 "p-47d_22_re_france_2";"⚜P-47D-22";;
-
+#
 "p-39q_25_france_shop";"⚜P-39Q-25 Airacobra";;
 "p-39q_25_france_0";"Bell Aircraft Corporation | ⚜P-39Q-25 Airacobra | Block 25";;
 "p-39q_25_france_1";"⚜P-39Q-25 Airacobra";;
 "p-39q_25_france_2";"⚜P-39Q-25";;
-
+#
 "p-51c-10_france_shop";"⚜F-6C-10 Mustang";;
 "p-51c-10_france_0";"North American Aviation | ⚜F-6C-10 Mustang | Block 10";;
 "p-51c-10_france_1";"⚜F-6C-10 Mustang";;
 "p-51c-10_france_2";"⚜F-6C-10";;
-
+#
 "p-63c-5_france_shop";"⚜P-63C-5 Kingcobra";;
 "p-63c-5_france_0";"Bell Aircraft Corporation | ⚜P-63C-5 Kingcobra | Block 5";;
 "p-63c-5_france_1";"⚜P-63C-5 Kingcobra";;
 "p-63c-5_france_2";"⚜P-63C-5";;
-
+#
 "b_26c_france_shop";"⚜B-26C Marauder";;
 "b_26c_france_0";"⚜Martin Company | B-26C Marauder";;
 "b_26c_france_1";"⚜B-26C Marauder";;
 "b_26c_france_2";"⚜B-26C";;
-
+#
 "pb4y-2_france_shop";"⚜PB4Y-2 Privateer";;
 "pb4y-2_france_0";"Consolidated Aircraft Corporation | ⚜PB4Y-2 Privateer";;
 "pb4y-2_france_1";"⚜PB4Y-2 Privateer";;
 "pb4y-2_france_2";"⚜PB4Y-2";;
-
+#
 "seafire_mk3_france_shop";"⚜Seafire Mk.III";;
 "seafire_mk3_france_0";"Supermarine Aviation Works | ⚜Seafire | Low-Altitude Fighter, Mk.III";;
 "seafire_mk3_france_1";"⚜Seafire Mk.III";;
 "seafire_mk3_france_2";"⚜Seafire Mk.III";;
-
+#
 "sea_fury_fb51_shop";"◘Sea Fury Mk.51";;
 "sea_fury_fb51_0";"Hawker Aircraft, Ltd. | ◘Sea Fury | Fighter-Bomber, Mk.51";;
 "sea_fury_fb51_1";"◘Sea Fury Mk.51";;
 "sea_fury_fb51_2";"◘Sea Fury Mk.51";;
-
+#
 "f4u-7_shop";"⚜F4U-7 Corsair";;
 "f4u-7_0";"Chance Vought Corporation | ⚜F4U-7 Corsair";;
 "f4u-7_1";"⚜F4U-7 Corsair";;
 "f4u-7_2";"⚜F4U-7";;
-
+#
 "spitfire_fr_mk14e_belgium_shop";"▄Spitfire Mk.XIVe";;
 "spitfire_fr_mk14e_belgium_0";"Supermarine Aviation Works | ▄Spitfire | Fighter/Reconnaissance, Mk.XIVe";;
 "spitfire_fr_mk14e_belgium_1";"▄Spitfire Mk.XIVe";;
 "spitfire_fr_mk14e_belgium_2";"▄Spitfire Mk.XIVe";;
-
+#
 "f6f-5n_france_shop";"⚜F6F-5N Hellcat";;
 "f6f-5n_france_0";"Grumman Aircraft Engineering Corporation | ⚜F6F-5N Hellcat";;
 "f6f-5n_france_1";"⚜F6F-5N Hellcat";;
 "f6f-5n_france_2";"⚜F6F-5N";;
-
+#
 "f8f1b_france_shop";"⚜F8F-1B Bearcat";;
 "f8f1b_france_0";"Grumman Aircraft Engineering Corporation | ⚜F8F-1B Bearcat";;
 "f8f1b_france_1";"⚜F8F-1B Bearcat";;
 "f8f1b_france_2";"⚜F8F-1B";;
-
+#
 "douglas_ad_4_france_shop";"⚜AD-4 Skyraider";;
 "douglas_ad_4_france_0";"Douglas Aircraft Company | ⚜AD-4 Skyraider";;
 "douglas_ad_4_france_1";"⚜AD-4 Skyraider";;
 "douglas_ad_4_france_2";"⚜AD-4";;
-
+#
 "douglas_ad_4na_france_shop";"⚜AD-4NA Skyraider";;
 "douglas_ad_4na_france_0";"Douglas Aircraft Company | ⚜AD-4NA Skyraider";;
 "douglas_ad_4na_france_1";"⚜AD-4NA SKyraider";;
 "douglas_ad_4na_france_2";"⚜AD-4NA";;
-
+#
 "meteor_fmk8_belgium_shop";"▄Meteor Mk.8";;
 "meteor_fmk8_belgium_0";"Gloster Aircraft Company, Ltd. | ▄Meteor | Fighter, Mk.8";;
 "meteor_fmk8_belgium_1";"▄Meteor Mk.8";;
 "meteor_fmk8_belgium_2";"▄Meteor Mk.8";;
-
+#
 "sea_hawk_fga50_netherlands_shop";"◘Sea Hawk Mk.50";;
 "sea_hawk_fga50_netherlands_0";"Hawker Aircraft, Ltd. | ◘Sea Hawk Mk.50";;
 "sea_hawk_fga50_netherlands_1";"◘Sea Hawk Mk.50";;
 "sea_hawk_fga50_netherlands_2";"◘Sea Hawk Mk.50";;
-
+#
 "so_4050_vautour_2n_shop";"Vautour IIN";;
 "so_4050_vautour_2n_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIN";;
 "so_4050_vautour_2n_1";"Vautour IIN";;
 "so_4050_vautour_2n_2";"Vautour IIN";;
-
+#
 "so_4050_vautour_2n_late_shop";"Vautour IIN (1973)";;
 "so_4050_vautour_2n_late_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIN (1973)";;
 "so_4050_vautour_2n_late_1";"Vautour IIN (1973)";;
 "so_4050_vautour_2n_late_2";"Vautour IIN (1973)";;
-
+#
 "md_452_mystere_2a_shop";"Mystère IIA";;
 "md_452_mystere_2a_0";"Société des Avions Marcel Dassault | M.D.452 Mystère IIA";;
 "md_452_mystere_2a_1";"Mystère IIA";;
 "md_452_mystere_2a_2";"Mystère IIA";;
-
+#
 "md_452_mystere_2c_preproduction_shop";"M.D.452 Mystère IIC (Preserie)";;
 "md_452_mystere_2c_preproduction_0";"Société des Avions Marcel Dassault | M.D.452 Mystère IIC (Preserie)";;
 "md_452_mystere_2c_preproduction_1";"M.D.452 Mystère IIC (Preserie)";;
 "md_452_mystere_2c_preproduction_2";"M.D.452 IIC";;
-
+#
 "md_454_mystere_4a_shop";"Mystère IVA";;
 "md_454_mystere_4a_0";"Société des Avions Marcel Dassault | M.D.454 Mystère IVA";;
 "md_454_mystere_4a_1";"Mystère IVA";;
 "md_454_mystere_4a_2";"Mystère IVA";;
-
+#
 "md_460_shop";"Super Mystère B2";;
 "md_460_0";"Société des Avions Marcel Dassault | M.D.460 Super Mystère B2";;
 "md_460_1";"Super Mystère B2";;
 "md_460_2";"Super Mystère B2";;
-
+#
 "md_460_yt_cup_2019_shop";"␙Super Mystère B2";;
 "md_460_yt_cup_2019_0";"Société des Avions Marcel Dassault | ␙M.D.460 Super Mystère B2";;
 "md_460_yt_cup_2019_1";"␙Super Mystère B2";;
 "md_460_yt_cup_2019_2";"␙Super Mystère B2";;
-
+#
 "f-86k_late_shop";"⚜F-86K Sabre";;
 "f-86k_late_0";"North American Aviation | ⚜F-86K Sabre";;
 "f-86k_late_1";"⚜F-86K Sabre";;
 "f-86k_late_2";"⚜F-86K";;
-
+#
 "alpha_jet_e_shop";"⚜Alpha Jet E";;
 "alpha_jet_e_0";"Dassault/Dornier | ⚜Alpha Jet E";;
 "alpha_jet_e_1";"⚜Alpha Jet E";;
 "alpha_jet_e_2";"⚜Alpha Jet E";;
-
+#
 "f-84g_france_shop";"⚜F-84G-26 Thunderjet";;
 "f-84g_france_0";"Republic Aviation Corporation | ⚜F-84G-26 Thunderjet | Block 26";;
 "f-84g_france_1";"⚜F-84G-26 Thunderjet";;
 "f-84g_france_2";"⚜F-84G-26";;
-
+#
 "f-84f_france_shop";"⚜F-84F Thunderstreak";;
 "f-84f_france_0";"Republic Aviation Corporation | ⚜F-84F Thunderstreak";;
 "f-84f_france_1";"⚜F-84F Thunderstreak";;
 "f-84f_france_2";"⚜F-84F";;
-
+#
 "f-100d_france_shop";"⚜F-100D Super Sabre";;
 "f-100d_france_0";"North American Aviation | ⚜F-100D Super Sabre";;
 "f-100d_france_1";"⚜F-100D Super Sabre";;
 "f-100d_france_2";"⚜F-100D";;
-
+#
 "so_4050_vautour_2a_shop";"Vautour IIA";;
 "so_4050_vautour_2a_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIA";;
 "so_4050_vautour_2a_1";"Vautour IIA";;
 "so_4050_vautour_2a_2";"Vautour IIA";;
-
+#
 "so_4050_vautour_2a_iaf_shop";"Vautour IIA";;
 "so_4050_vautour_2a_iaf_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIA";;
 "so_4050_vautour_2a_iaf_1";"Vautour IIA";;
 "so_4050_vautour_2a_iaf_2";"Vautour IIA";;
-
+#
 "so_4050_vautour_2b_shop";"Vautour IIB";;
 "so_4050_vautour_2b_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIB";;
 "so_4050_vautour_2b_1";"Vautour IIB";;
 "so_4050_vautour_2b_2";"Vautour IIB";;
-
+#
 "hunter_f6_holland_shop";"◘Hunter Mk.6";;
 "hunter_f6_holland_0";"Hawker Aircraft, Ltd. | ◘Hunter | Fighter, Mk.6";;
 "hunter_f6_holland_1";"◘Hunter Mk.6";;
 "hunter_f6_holland_2";"◘Hunter Mk.6";;
-
+#
 "mirage_milan_shop";"Milan S 01";;
 "mirage_milan_0";"Société des Avions Marcel Dassault | Milan S 01";;
 "mirage_milan_1";"Milan S 01";;
 "mirage_milan_2";"Milan S 01";;
-
+#
 "etndard_4m_shop";"Etendard IV M";;
 "etndard_4m_0";"Société des Avions Marcel Dassault | Etendard IV M";;
 "etndard_4m_1";"Etendard IV M";;
 "etndard_4m_2";"Etendard IV M";;
-
+#
 "mirage_3c_shop";"Mirage III C";;
 "mirage_3c_0";"Société des Avions Marcel Dassault | Mirage III C";;
 "mirage_3c_1";"Mirage III C";;
 "mirage_3c_2";"Mirage III C";;
-
+#
 "mirage_3e_shop";"Mirage III E";;
 "mirage_3e_0";"Société des Avions Marcel Dassault | Mirage III E";;
 "mirage_3e_1";"Mirage III E";;
 "mirage_3e_2";"Mirage III E";;
-
+#
 "f-8e_fn_shop";"⚜F-8E(FN) Crusader II";;
 "f-8e_fn_0";"Chance Vought Corporation | ⚜F-8E(FN) Crusader II";;
 "f-8e_fn_1";"⚜F-8E(FN) Crusader II";;
 "f-8e_fn_2";"⚜F-8E(FN)";;
-
+#
 "mirage_5f_shop";"Mirage 5 F";;
 "mirage_5f_0";"Société des Avions Marcel Dassault | Mirage 5 F";;
 "mirage_5f_1";"Mirage 5 F";;
 "mirage_5f_2";"Mirage 5 F";;
-
+#
 "mirage_5ba_shop";"▄Mirage 5 BA";;
 "mirage_5ba_0";"Sociétés Anonyme Belge de Constructions Aéronautiques (SABCA) | ▄Mirage 5 BA";;
 "mirage_5ba_1";"▄Mirage 5 BA";;
 "mirage_5ba_2";"▄Mirage 5 BA";;
-
+#
 "super_etendard_97_shop";"Super Etendard Modernisé (1997)";;
 "super_etendard_97_0";"Société des Avions Marcel Dassault-Breguet | Super Etendard Modernisé (1997)";;
 "super_etendard_97_1";"Super Etendard Modernisé (1997)";;
 "super_etendard_97_2";"Super Etendard";;
-
+#
 "jaguar_a_shop";"⚜Jaguar A";;
 "jaguar_a_0";"Société Européenne de Production de l'avion Ecole de Combat et d'Appui Tactique (SEPECAT) | ⚜Jaguar A";;
 "jaguar_a_1";"⚜Jaguar A";;
 "jaguar_a_2";"⚜Jaguar A";;
-
+#
 "jaguar_e_shop";"⚜Jaguar E";;
 "jaguar_e_0";"Société Européenne de Production de l'avion Ecole de Combat et d'Appui Tactique (SEPECAT) | ⚜Jaguar E";;
 "jaguar_e_1";"⚜Jaguar E";;
 "jaguar_e_2";"⚜Jaguar E";;
-
+#
 "f-104g_belgium_shop";"▄F-104G Starfighter";;
 "f-104g_belgium_0";"Sociétés Anonyme Belge de Constructions Aéronautiques (SABCA) | ▄F-104G Starfighter";;
 "f-104g_belgium_1";"▄F-104G Starfighter";;
 "f-104g_belgium_2";"▄F-104G";;
-
+#
 "mirage_f1c_200_shop";"Mirage F1 C-200";;
 "mirage_f1c_200_0";"Société des Avions Marcel Dassault | Mirage F1 C-200";;
 "mirage_f1c_200_1";"Mirage F1 C-200";;
 "mirage_f1c_200_2";"Mirage F1 C-200";;
-
+#
 "mirage_f1c_shop";"Mirage F1 C";;
 "mirage_f1c_0";"Société des Avions Marcel Dassault | Mirage F1 C";;
 "mirage_f1c_1";"Mirage F1 C";;
 "mirage_f1c_2";"Mirage F1 C";;
-
+#
 "mirage_f1ct_shop";"Mirage F1 CT";;
 "mirage_f1ct_0";"Société des Avions Marcel Dassault | Mirage F1 CT";;
 "mirage_f1ct_1";"Mirage F1 CT";;
 "mirage_f1ct_2";"Mirage F1 CT";;
-
+#
 "mirage_2000c_s4_shop";"Mirage 2000 C-S4";;
 "mirage_2000c_s4_0";"Société des Avions Marcel Dassault | Mirage 2000 C-S4";;
 "mirage_2000c_s4_1";"Mirage 2000 C-S4";;
 "mirage_2000c_s4_2";"Mirage 2000 C-S4";;
-
+#
 "mirage_2000c_s5_shop";"Mirage 2000 C-S5";;
 "mirage_2000c_s5_0";"Société des Avions Marcel Dassault | Mirage 2000 C-S5";;
 "mirage_2000c_s5_1";"Mirage 2000 C-S5";;
 "mirage_2000c_s5_2";"Mirage 2000 C-S5";;
-
+#
 "f_16a_block_15_belgium_shop";"▄F-16A-15 Viper";;
 "f_16a_block_15_belgium_0";"Sociétés Anonyme Belge de Constructions Aéronautiques (SABCA) | ▄F-16A-15 Viper | Block 15";;
 "f_16a_block_15_belgium_1";"▄F-16A-15 Viper";;
 "f_16a_block_15_belgium_2";"▄F-16A-15";;
-
+#
 "f_16am_block_15_mlu_belgium_shop";"▄F-16AM-15 Viper";;
 "f_16am_block_15_mlu_belgium_0";"Sociétés Anonyme Belge de Constructions Aéronautiques (SABCA) | ▄F-16AM-15 Viper | Block 15 | Mid-Life Update (2000)";;
 "f_16am_block_15_mlu_belgium_1";"▄F-16AM-15 Viper";;
 "f_16am_block_15_mlu_belgium_2";"▄F-16AM-15";;
-
+#
 "mirage_2000_5f_shop";"Mirage 2000-5F";;
 "mirage_2000_5f_0";"Société des Avions Marcel Dassault | Mirage 2000-5F";;
 "mirage_2000_5f_1";"Mirage 2000-5F";;
 "mirage_2000_5f_2";"Mirage 2000-5F";;
-
+#
 "mirage_2000_5f_missile_test_shop";"Mirage 2000-5F";;
 "mirage_2000_5f_missile_test_0";"Dassault Aviation SA | Mirage 2000-5F";;
 "mirage_2000_5f_missile_test_1";"Mirage 2000-5F";;
 "mirage_2000_5f_missile_test_2";"Mirage 2000-5F";;
-
+#
 "mirage_2000d_r1_shop";"Mirage 2000 D-R1";;
 "mirage_2000d_r1_0";"Dassault Aviation SA | Mirage 2000 D-R1";;
 "mirage_2000d_r1_1";"Mirage 2000 D-R1";;
 "mirage_2000d_r1_2";"Mirage 2000 D-R1";;
-
+#
 "mirage_2000d_rmv_shop";"Mirage 2000 D-RMV";;
 "mirage_2000d_rmv_0";"Dassault Aviation SA | Mirage 2000 D Rénovation Mi-Vie";;
 "mirage_2000d_rmv_1";"Mirage 2000 D-RMV";;
 "mirage_2000d_rmv_2";"Mirage 2000 D-RMV";;
-
+#
 "mirage_4000_shop";"Mirage 4000";;
 "mirage_4000_0";"Société des Avions Marcel Dassault | Mirage 4000";;
 "mirage_4000_1";"Mirage 4000";;
 "mirage_4000_2";"Mirage 4000";;
-
+#
 "rafale_c_f3_shop";"Rafale C F3-R";;
 "rafale_c_f3_0";"Dassault Aviation SA | Rafale Chasseur F3-R";;
 "rafale_c_f3_1";"Rafale C F3-R";;
 "rafale_c_f3_2";"Rafale C F3-R";;
-
+#
 "nf_5a_netherlands_shop";"◘NF-5A Freedom Fighter";;
 "nf_5a_netherlands_0";"Canadair, Ltd. | ◘NF-5A Freedom Fighter";;
 "nf_5a_netherlands_1";"◘NF-5A Freedom Fighter";;
 "nf_5a_netherlands_2";"◘NF-5A";;
-
+#
 "f_16a_block_15_ocu_belgium_shop";"▄F-16A-15OCU Viper";;
 "f_16a_block_15_ocu_belgium_0";"Sociétés Anonyme Belge de Constructions Aéronautiques (SABCA) | ▄F-16A-15OCU Viper | Block 15 | Operational Capability Upgrade (1988)";;
 "f_16a_block_15_ocu_belgium_1";"▄F-16A-15OCU Viper";;
 "f_16a_block_15_ocu_belgium";"▄F-16A-15OCU";;
-
+#
 "fokker_d23_shop";"◗Fokker D.XXIII";;
 "fokker_d23_0";"N.V. Koninklijke Nederlandse Vliegtuigenfabriek Fokker | ◗Fokker D.XXIII";;
 "fokker_d23_1";"◗Fokker D.XXIII";;
 "fokker_d23_2";"◗Fokker D.XXIII";;
-
+#
 "shop/group/md_452_group";"M.D.452 Mystere II";;
 "shop/group/md_454_group";"Mystère/Super Mystère";;
 "shop/group/so_4050_vautour_group";"S.O.4050 Vautour II";;
@@ -537,3 +536,10 @@ noverify>";"<English>";
 "shop/group/h-75_france_group";"H-75";;
 "shop/group/d_500_group";"D.500";;
 "shop/group/maryland_group";"Martin 167/M.B.174A";;
+#
+#helicopters
+#RANK 7
+ah_64e_netherlands_shop;◘AH-64E Guardian Apache (v6);;
+ah_64e_netherlands_0;Boeing Defense, Space & Security | ◘Helicopter, Attack, AH-64E Guardian Apache | Capability Version 6;;
+ah_64e_netherlands_1;◘AH-64E Guardian Apache (v6);;
+ah_64e_netherlands_2;◘AH-64E (v6);;

--- a/Mod Files/syrup_units_gb.csv
+++ b/Mod Files/syrup_units_gb.csv
@@ -1,5 +1,4 @@
-"<ID|readonly|
-noverify>";"<English>";
+"<ID|readonly|noverify>";"<English>";
 
 "lancaster_mk1_shop";"Lancaster B.I";;
 "lancaster_mk1_0";"A.V. Roe and Company | Lancaster | Bomber, Mk.I";;
@@ -701,4 +700,10 @@ noverify>";"<English>";
 "shop/group/seafire_group";"Seafire";;
 "shop/group/spitfire_griffon_group";"Spitfire F.22/24";;
 "shop/group/hawk_200_group";"Hawk 200/200 (RDA)";;
+
+//helicopters
+"ah_64e_britain_shop";"▄Apache AH.2";;
+"ah_64e_britain_0";"Boeing Defense, Space & Security | ▄Apache | Attack Helicopter, Mk.2";;
+"ah_64e_britain_1";"▄Apache AH.2";;
+"ah_64e_britain_2";"▄Apache AH.2";;
 

--- a/Mod Files/syrup_units_isr.csv
+++ b/Mod Files/syrup_units_isr.csv
@@ -1,187 +1,193 @@
-"<ID|readonly|
-noverify>";"<English>";
-
-"b-17g_iaf_shop";"B-17G-60 Flying Fortress";;
-"b-17g_iaf_0";"Boeing Airplane Company | B-17G-60 Flying Fortress | Block 60";;
-"b-17g_iaf_1";"B-17G-60 Flying Fortress";;
-"b-17g_iaf_2";"B-17G-60";;
-
-"s_199_shop";"S-199 Sakeen";;
-"s_199_0";"Avia Motors s.r.o. | S-199 Sakeen";;
-"s_199_1";"S-199 Sakeen";;
-"s_199_2";"S-199";;
-
-"p-51d-20-na_iaf_shop";"P-51D-20 Mustang";;
-"p-51d-20-na_iaf_0";"North American Aviation | P-51D-20 Mustang | Block 20";;
-"p-51d-20-na_iaf_1";"P-51D-20 Mustang";;
-"p-51d-20-na_iaf_2";"P-51D-20";;
-
-"spitfire_lf_mk9e_weisman_shop";"Spitfire LF.IXe [Weizman]";;
-"spitfire_lf_mk9e_weisman_0";"Supermarine Aviation Works | Ezer Weizman's Spitfire | Low-Altitude Fighter, Mk.IXe";;
-"spitfire_lf_mk9e_weisman_1";"Spitfire LF.IXe [Weizman]";;
-"spitfire_lf_mk9e_weisman_2";"Spitfire LF.IXe";;
-
-"spitfire_lf_mk9e_iaf_shop";"Spitfire LF.IX (CW)";;
-"spitfire_lf_mk9e_iaf_0";"Supermarine Aviation Works | Spitfire | Low-Altitude Fighter, Mk.IX (Clipped Wings)";;
-"spitfire_lf_mk9e_iaf_1";"Spitfire LF.IX (CW)";;
-"spitfire_lf_mk9e_iaf_2";"Spitfire LF.IX (CW)";;
-
-"spitfire_mk9c_iaf_shop";"Spitfire LF.IXc";;
-"spitfire_mk9c_iaf_0";"Supermarine Aviation Works | Spitfire | Low-Altitude Fighter, Mk.IXc";;
-"spitfire_mk9c_iaf_1";"Spitfire LF.IXc";;
-"spitfire_mk9c_iaf_2";"Spitfire LF.IXc";;
-
-"meteor_frmk9_iaf_shop";"Meteor FR.9";;
-"meteor_frmk9_iaf_0";"Gloster Aircraft Company, Ltd. | Meteor | Fighter, Reconnaissance, Mk.9";;
-"meteor_frmk9_iaf_1";"Meteor FR.9";;
-"meteor_frmk9_iaf_2";"Meteor FR.9";;
-
-"meteor_fmk8_iaf_shop";"Meteor F.8";;
-"meteor_fmk8_iaf_0";"Gloster Aircraft Company, Ltd. | Meteor | Fighter, Mk.8";;
-"meteor_fmk8_iaf_1";"Meteor F.8";;
-"meteor_fmk8_iaf_2";"Meteor F.8";;
-
-"meteor_nfmk13_shop";"Meteor NF.13";;
-"meteor_nfmk13_0";"Sir W.G. Armstrong Whitworth & Co., Ltd. | Meteor | Night Fighter, Mk.13";;
-"meteor_nfmk13_1";"Meteor NF.13";;
-"meteor_nfmk13_2";"Meteor NF.13";;
-
-"md_450b_ouragan_iaf_shop";"Ouragan";;
-"md_450b_ouragan_iaf_0";"Société des Avions Marcel Dassault | M.D.450B Ouragan";;
-"md_450b_ouragan_iaf_1";"Ouragan";;
-"md_450b_ouragan_iaf_2";"Ouragan";;
-
-"so_4050_vautour_2a_israel_iaf_shop";"Vautour IIA";;
-"so_4050_vautour_2a_israel_iaf_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIA";;
-"so_4050_vautour_2a_israel_iaf_1";"Vautour IIA";;
-"so_4050_vautour_2a_israel_iaf_2";"Vautour IIA";;
-
-"so_4050_vautour_2n_iaf_shop";"Vautour IIN";;
-"so_4050_vautour_2n_iaf_0";"Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIN";;
-"so_4050_vautour_2n_iaf_1";"Vautour IIN";;
-"so_4050_vautour_2n_iaf_2";"Vautour IIN";;
-
-"a_4h_shop";"A-4H Skyhawk";;
-"a_4h_0";"Douglas Aircraft Company | A-4H Skyhawk";;
-"a_4h_1";"A-4H Skyhawk";;
-"a_4h_2";"A-4H";;
-
-"a_4e_late_iaf_shop";"A-4E Skyhawk (1973)";;
-"a_4e_late_iaf_0";"Douglas Aircraft Company | A-4E Skyhawk (1973)";;
-"a_4e_late_iaf_1";"A-4E Skyhawk (1973)";;
-"a_4e_late_iaf_2";"A-4E (1973)";;
-
-"a_4e_early_iaf_shop";"A-4E(M) Skyhawk (1973)";;
-"a_4e_early_iaf_0";"Douglas Aircraft Company | A-4E(M) Skyhawk (1973)";;
-"a_4e_early_iaf_1";"A-4E(M) Skyhawk (1973)";;
-"a_4e_early_iaf_2";"A-4E(M) (1973)";;
-
-"a_4n_shop";"A-4N Ayit";;
-"a_4n_0";"Douglas Aircraft Company | A-4N Ayit";;
-"a_4n_1";"A-4N Ayit";;
-"a_4n_2";"A-4N";;
-
-"md_454_mystere_4a_iaf_shop";"Mystère IVA";;
-"md_454_mystere_4a_iaf_0";"Société des Avions Marcel Dassault | M.D.454 Mystère IVA";;
-"md_454_mystere_4a_iaf_1";"Mystère IVA";;
-"md_454_mystere_4a_iaf_2";"Mystère IVA";;
-
-"md_460_sambad_shop";"Super Mystère B2 Sambad";;
-"md_460_sambad_0";"Société des Avions Marcel Dassault | M.D.460 Super Mystère B2 Sambad";;
-"md_460_sambad_1";"Super Mystère B2 Sambad;;
-"md_460_sambad_2";"Super Mystère B2;;
-
-"md_460_saar_shop";"Sa'ar";;
-"md_460_saar_0";"Société des Avions Marcel Dassault | Sa'ar | M.D.460 Super Mystère B2";;
-"md_460_saar_1";"Sa'ar";;
-"md_460_saar_2";"Sa'ar";;
-
-"mirage_3cj_shop";"Mirage III CJ Shahak";;
-"mirage_3cj_0";"Société des Avions Marcel Dassault | Mirage III CJ Shahak";;
-"mirage_3cj_1";"Mirage III CJ Shahak";;
-"mirage_3cj_2";"Mirage III CJ";;
-
-"nesher_shop";"Nesher";;
-"nesher_0";"Israeli Aircraft Industries (IAI) | Nesher | Mirage 5 F";;
-"nesher_1";"Nesher";;
-"nesher_2";"Nesher";;
-
-"kfir_canard_shop";"Kfir C.1P Gderot";;
-"kfir_canard_0";"Israeli Aircraft Industries (IAI) | Kfir C.1P Gderot";;
-"kfir_canard_1";"Kfir C.1P Gderot";;
-"kfir_canard_2";"Kfir C.1P";;
-
-"kfir_c2_shop";"Kfir C.2";;
-"kfir_c2_0";"Israeli Aircraft Industries (IAI) | Kfir C.2";;
-"kfir_c2_1";"Kfir C.2";;
-"kfir_c2_2";"Kfir C.2";;
-
-"kfir_c7_shop";"Kfir C.7";;
-"kfir_c7_0";"Israeli Aircraft Industries (IAI) | Kfir C.7";;
-"kfir_c7_1";"Kfir C.7";;
-"kfir_c7_2";"Kfir C.7";;
-
-"f-4e_iaf_shop";"F-4E Kurnass";;
-"f-4e_iaf_0";"McDonnell Douglas Aircraft Company | F-4E Kurnass";;
-"f-4e_iaf_1";"F-4E Kurnass";;
-"f-4e_iaf_2";"F-4E";;
-
-"f-4e_kurnass_2000_shop";"F-4E-2000 Kurnass";;
-"f-4e_kurnass_2000_0";"Israeli Aircraft Industries (IAI) | F-4E-2000 Kurnass";;
-"f-4e_kurnass_2000_1";"F-4E-2000 Kurnass";;
-"f-4e_kurnass_2000_2";"F-4E-2000";;
-
-"f_16d_block_40_barak_2_shop";"F-16D-40 Barak II";;
-"f_16d_block_40_barak_2_0";"General Dynamics Corporation | F-16D-40 Barak II | Block 40";;
-"f_16d_block_40_barak_2_1";"F-16D-40 Barak II";;
-"f_16d_block_40_barak_2_2";"F-16D-40";;
-
-"f_16d_block_40_barak_2_missile_test_shop";"F-16D-40 Barak II";;
-"f_16d_block_40_barak_2_missile_test_0";"General Dynamics Corporation | F-16D-40 Barak II | Block 40";;
-"f_16d_block_40_barak_2_missile_test_1";"F-16D-40 Barak II";;
-"f_16d_block_40_barak_2_missile_test_2";"F-16D-40";;
-
-"f_16c_block_40_barak_2_shop";"F-16C-40 Barak II";;
-"f_16c_block_40_barak_2_0";"General Dynamics Corporation | F-16C-40 Barak II | Block 40";;
-"f_16c_block_40_barak_2_1";"F-16C-40 Barak II";;
-"f_16c_block_40_barak_2_2";"F-16C-40";;
-
-"f_16a_block_10_iaf_shop";"F-16A-10 Netz";;
-"f_16a_block_10_iaf_0";"General Dynamics Corporation | F-16A-10 Netz | Block 10";;
-"f_16a_block_10_iaf_1";"F-16A-10 Netz";;
-"f_16a_block_10_iaf_2";"F-16A-10";;
-
-"f_16a_block_10_netz_mod_shop";"F-16A-5 Netz (115 SQN)";;
-"f_16a_block_10_netz_mod_0";"General Dynamics Corporation | F-16A-5 Netz | Block 5 | 115 Squadron ""Red Squadron""";;
-"f_16a_block_10_netz_mod_1";"F-16A-5 Netz (115 SQN)";;
-"f_16a_block_10_netz_mod_2";"F-16A-5 (115 SQN)";;
-
-"kfir_c10_colombia_shop";"◡Kfir COA";;
-"kfir_c10_colombia_0";"Israeli Aircraft Industries (IAI) | ◡Kfir COA | Block 60";;
-"kfir_c10_colombia_1";"◡Kfir COA";;
-"kfir_c10_colombia_2";"◡Kfir COA";;
-
-"f_15a_iaf_shop";"F-15A-18 Baz";;
-"f_15a_iaf_0";"McDonnell Douglas Aircraft Company | F-15A-18 Baz | Block 18";;
-"f_15a_iaf_1";"F-15A-18 Baz";;
-"f_15a_iaf_2";"F-15A-18";;
-
-"f_15c_baz_msip_shop";"F-15A-2000 Baz Meshupar";;
-"f_15c_baz_msip_0";"McDonnell Douglas Aircraft Company | F-15A-2000 Baz | Baz 2000/Meshupar Program (1995)";;
-"f_15c_baz_msip_1";"F-15A-2000 Baz Meshupar";;
-"f_15c_baz_msip_2";"F-15A-2000";;
-
-"f_15i_raam_shop";"F-15I Ra’am";;
-"f_15i_raam_0";"McDonnell Douglas Aircraft Company | F-15I Ra’am";;
-"f_15i_raam_1";"F-15I Ra'am";;
-"f_15i_raam_2";"F-15I";;
-
-"f_16i_sufa_shop";"F-16I-52+ Sufa";;
-"f_16i_sufa_0";"General Dynamics Corporation | F-16I-52+ Sufa | Block 52+";;
-"f_16i_sufa_1";"F-16I-52+ Sufa";;
-"f_16i_sufa_2";"F-16I-52+";;
-
-"md_450b_ouragan_iaf_29_shop";"'Organ";;
-"md_450b_ouragan_iaf_29_0";"Société des Avions Marcel Dassault | M.D.450B 'Organ";;
-"md_450b_ouragan_iaf_29_1";"'Organ";;
-"md_450b_ouragan_iaf_29_2";"'Organ";;
+<ID|readonly|noverify>;<English>;;
+#
+#removed all the quotation marks because Edit CSV kept throwing a malformed trailing quote error on Line 90 and i cba to find the actual cause -maple (11/13/2025)
+#
+b-17g_iaf_shop;B-17G-60 Flying Fortress;;
+b-17g_iaf_0;Boeing Airplane Company | B-17G-60 Flying Fortress | Block 60;;
+b-17g_iaf_1;B-17G-60 Flying Fortress;;
+b-17g_iaf_2;B-17G-60;;
+#
+s_199_shop;S-199 Sakeen;;
+s_199_0;Avia Motors s.r.o. | S-199 Sakeen;;
+s_199_1;S-199 Sakeen;;
+s_199_2;S-199;;
+#
+p-51d-20-na_iaf_shop;P-51D-20 Mustang;;
+p-51d-20-na_iaf_0;North American Aviation | P-51D-20 Mustang | Block 20;;
+p-51d-20-na_iaf_1;P-51D-20 Mustang;;
+p-51d-20-na_iaf_2;P-51D-20;;
+#
+spitfire_lf_mk9e_weisman_shop;Spitfire LF.IXe [Weizman];;
+spitfire_lf_mk9e_weisman_0;Supermarine Aviation Works | Ezer Weizman's Spitfire | Low-Altitude Fighter, Mk.IXe;;
+spitfire_lf_mk9e_weisman_1;Spitfire LF.IXe [Weizman];;
+spitfire_lf_mk9e_weisman_2;Spitfire LF.IXe;;
+#
+spitfire_lf_mk9e_iaf_shop;Spitfire LF.IX (CW);;
+spitfire_lf_mk9e_iaf_0;Supermarine Aviation Works | Spitfire | Low-Altitude Fighter, Mk.IX (Clipped Wings);;
+spitfire_lf_mk9e_iaf_1;Spitfire LF.IX (CW);;
+spitfire_lf_mk9e_iaf_2;Spitfire LF.IX (CW);;
+#
+spitfire_mk9c_iaf_shop;Spitfire LF.IXc;;
+spitfire_mk9c_iaf_0;Supermarine Aviation Works | Spitfire | Low-Altitude Fighter, Mk.IXc;;
+spitfire_mk9c_iaf_1;Spitfire LF.IXc;;
+spitfire_mk9c_iaf_2;Spitfire LF.IXc;;
+#
+meteor_frmk9_iaf_shop;Meteor FR.9;;
+meteor_frmk9_iaf_0;Gloster Aircraft Company, Ltd. | Meteor | Fighter, Reconnaissance, Mk.9;;
+meteor_frmk9_iaf_1;Meteor FR.9;;
+meteor_frmk9_iaf_2;Meteor FR.9;;
+#
+meteor_fmk8_iaf_shop;Meteor F.8;;
+meteor_fmk8_iaf_0;Gloster Aircraft Company, Ltd. | Meteor | Fighter, Mk.8;;
+meteor_fmk8_iaf_1;Meteor F.8;;
+meteor_fmk8_iaf_2;Meteor F.8;;
+#
+meteor_nfmk13_shop;Meteor NF.13;;
+meteor_nfmk13_0;Sir W.G. Armstrong Whitworth & Co., Ltd. | Meteor | Night Fighter, Mk.13;;
+meteor_nfmk13_1;Meteor NF.13;;
+meteor_nfmk13_2;Meteor NF.13;;
+#
+md_450b_ouragan_iaf_shop;Ouragan;;
+md_450b_ouragan_iaf_0;Société des Avions Marcel Dassault | M.D.450B Ouragan;;
+md_450b_ouragan_iaf_1;Ouragan;;
+md_450b_ouragan_iaf_2;Ouragan;;
+#
+so_4050_vautour_2a_israel_iaf_shop;Vautour IIA;;
+so_4050_vautour_2a_israel_iaf_0;Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIA;;
+so_4050_vautour_2a_israel_iaf_1;Vautour IIA;;
+so_4050_vautour_2a_israel_iaf_2;Vautour IIA;;
+#
+so_4050_vautour_2n_iaf_shop;Vautour IIN;;
+so_4050_vautour_2n_iaf_0;Société Nationale des Constructions Aéronautiques du Sud-Ouest (SNCASO) | S.O.4050 Vautour IIN;;
+so_4050_vautour_2n_iaf_1;Vautour IIN;;
+so_4050_vautour_2n_iaf_2;Vautour IIN;;
+#
+a_4h_shop;A-4H Skyhawk;;
+a_4h_0;Douglas Aircraft Company | A-4H Skyhawk;;
+a_4h_1;A-4H Skyhawk;;
+a_4h_2;A-4H;;
+#
+a_4e_late_iaf_shop;A-4E Skyhawk (1973);;
+a_4e_late_iaf_0;Douglas Aircraft Company | A-4E Skyhawk (1973);;
+a_4e_late_iaf_1;A-4E Skyhawk (1973);;
+a_4e_late_iaf_2;A-4E (1973);;
+#
+a_4e_early_iaf_shop;A-4E(M) Skyhawk (1973);;
+a_4e_early_iaf_0;Douglas Aircraft Company | A-4E(M) Skyhawk (1973);;
+a_4e_early_iaf_1;A-4E(M) Skyhawk (1973);;
+a_4e_early_iaf_2;A-4E(M) (1973);;
+#
+a_4n_shop;A-4N Ayit;;
+a_4n_0;Douglas Aircraft Company | A-4N Ayit;;
+a_4n_1;A-4N Ayit;;
+a_4n_2;A-4N;;
+#
+md_454_mystere_4a_iaf_shop;Mystère IVA;;
+md_454_mystere_4a_iaf_0;Société des Avions Marcel Dassault | M.D.454 Mystère IVA;;
+md_454_mystere_4a_iaf_1;Mystère IVA;;
+md_454_mystere_4a_iaf_2;Mystère IVA;;
+#
+md_460_sambad_shop;Super Mystère B2 Sambad;;
+md_460_sambad_0;Société des Avions Marcel Dassault | M.D.460 Super Mystère B2 Sambad;;
+md_460_sambad_1;Super Mystère B2 Sambad;;
+md_460_sambad_2;Super Mystère B2;;
+#
+md_460_saar_shop;Sa'ar;;
+md_460_saar_0;Société des Avions Marcel Dassault | Sa'ar | M.D.460 Super Mystère B2;;
+md_460_saar_1;Sa'ar;;
+md_460_saar_2;Sa'ar;;
+#
+mirage_3cj_shop;Mirage III CJ Shahak;;
+mirage_3cj_0;Société des Avions Marcel Dassault | Mirage III CJ Shahak;;
+mirage_3cj_1;Mirage III CJ Shahak;;
+mirage_3cj_2;Mirage III CJ;;
+#
+nesher_shop;Nesher;;
+nesher_0;Israeli Aircraft Industries (IAI) | Nesher | Mirage 5 F;;
+nesher_1;Nesher;;
+nesher_2;Nesher;;
+#
+kfir_canard_shop;Kfir C.1P Gderot;;
+kfir_canard_0;Israeli Aircraft Industries (IAI) | Kfir C.1P Gderot;;
+kfir_canard_1;Kfir C.1P Gderot;;
+kfir_canard_2;Kfir C.1P;;
+#
+kfir_c2_shop;Kfir C.2;;
+kfir_c2_0;Israeli Aircraft Industries (IAI) | Kfir C.2;;
+kfir_c2_1;Kfir C.2;;
+kfir_c2_2;Kfir C.2;;
+#
+kfir_c7_shop;Kfir C.7;;
+kfir_c7_0;Israeli Aircraft Industries (IAI) | Kfir C.7;;
+kfir_c7_1;Kfir C.7;;
+kfir_c7_2;Kfir C.7;;
+#
+f-4e_iaf_shop;F-4E Kurnass;;
+f-4e_iaf_0;McDonnell Douglas Aircraft Company | F-4E Kurnass;;
+f-4e_iaf_1;F-4E Kurnass;;
+f-4e_iaf_2;F-4E;;
+#
+f-4e_kurnass_2000_shop;F-4E-2000 Kurnass;;
+f-4e_kurnass_2000_0;Israeli Aircraft Industries (IAI) | F-4E-2000 Kurnass;;
+f-4e_kurnass_2000_1;F-4E-2000 Kurnass;;
+f-4e_kurnass_2000_2;F-4E-2000;;
+#
+f_16d_block_40_barak_2_shop;F-16D-40 Barak II;;
+f_16d_block_40_barak_2_0;General Dynamics Corporation | F-16D-40 Barak II | Block 40;;
+f_16d_block_40_barak_2_1;F-16D-40 Barak II;;
+f_16d_block_40_barak_2_2;F-16D-40;;
+#
+f_16d_block_40_barak_2_missile_test_shop;F-16D-40 Barak II;;
+f_16d_block_40_barak_2_missile_test_0;General Dynamics Corporation | F-16D-40 Barak II | Block 40;;
+f_16d_block_40_barak_2_missile_test_1;F-16D-40 Barak II;;
+f_16d_block_40_barak_2_missile_test_2;F-16D-40;;
+#
+f_16c_block_40_barak_2_shop;F-16C-40 Barak II;;
+f_16c_block_40_barak_2_0;General Dynamics Corporation | F-16C-40 Barak II | Block 40;;
+f_16c_block_40_barak_2_1;F-16C-40 Barak II;;
+f_16c_block_40_barak_2_2;F-16C-40;;
+#
+f_16a_block_10_iaf_shop;F-16A-10 Netz;;
+f_16a_block_10_iaf_0;General Dynamics Corporation | F-16A-10 Netz | Block 10;;
+f_16a_block_10_iaf_1;F-16A-10 Netz;;
+f_16a_block_10_iaf_2;F-16A-10;;
+#
+f_16a_block_10_netz_mod_shop;F-16A-5 Netz (115 SQN);;
+f_16a_block_10_netz_mod_0;General Dynamics Corporation | F-16A-5 Netz | Block 5 | 115 Squadron Red Squadron;;
+f_16a_block_10_netz_mod_1;F-16A-5 Netz (115 SQN);;
+f_16a_block_10_netz_mod_2;F-16A-5 (115 SQN);;
+#
+kfir_c10_colombia_shop;◡Kfir COA;;
+kfir_c10_colombia_0;Israeli Aircraft Industries (IAI) | ◡Kfir COA | Block 60;;
+kfir_c10_colombia_1;◡Kfir COA;;
+kfir_c10_colombia_2;◡Kfir COA;;
+#
+f_15a_iaf_shop;F-15A-18 Baz;;
+f_15a_iaf_0;McDonnell Douglas Aircraft Company | F-15A-18 Baz | Block 18;;
+f_15a_iaf_1;F-15A-18 Baz;;
+f_15a_iaf_2;F-15A-18;;
+#
+f_15c_baz_msip_shop;F-15A-2000 Baz Meshupar;;
+f_15c_baz_msip_0;McDonnell Douglas Aircraft Company | F-15A-2000 Baz | Baz 2000/Meshupar Program (1995);;
+f_15c_baz_msip_1;F-15A-2000 Baz Meshupar;;
+f_15c_baz_msip_2;F-15A-2000;;
+#
+f_15i_raam_shop;F-15I Ra’am;;
+f_15i_raam_0;McDonnell Douglas Aircraft Company | F-15I Ra’am;;
+f_15i_raam_1;F-15I Ra'am;;
+f_15i_raam_2;F-15I;;
+#
+f_16i_sufa_shop;F-16I-52+ Sufa;;
+f_16i_sufa_0;General Dynamics Corporation | F-16I-52+ Sufa | Block 52+;;
+f_16i_sufa_1;F-16I-52+ Sufa;;
+f_16i_sufa_2;F-16I-52+;;
+#
+md_450b_ouragan_iaf_29_shop;'Organ;;
+md_450b_ouragan_iaf_29_0;Société des Avions Marcel Dassault | M.D.450B 'Organ;;
+md_450b_ouragan_iaf_29_1;'Organ;;
+md_450b_ouragan_iaf_29_2;'Organ;;
+#
+f_111f_iaf_killstreak_shop;☢F-111F Aardvark;;
+f_111f_iaf_killstreak_0;General Dynamics Corporation | ☢F-111F Aardvark;;
+f_111f_iaf_killstreak_1;☢F-111F Aardvark;;
+f_111f_iaf_killstreak_2;☢F-111F;;

--- a/Mod Files/syrup_units_jp.csv
+++ b/Mod Files/syrup_units_jp.csv
@@ -1,661 +1,660 @@
-"<ID|readonly|
-noverify>";"<English>";
-
+"<ID|readonly|noverify>";"<English>";;
+#
 "kitsuka_shop";"M7N1-J Kō Kikka Kai";;
 "kitsuka_0";"Nakajima Aircraft | M7N1-J Kikka Kai | Experimental Model 21 Kō";;
 "kitsuka_1";"M7N1-J Kō Kikka Kai";;
 "kitsuka_2";"M7N1-J Kō";;
-
+#
 "j8m1_shop";"Ki 200";;
 "j8m1_0";"Mitsubishi Heavy Industries | Ki 200";;
 "j8m1_1";"Ki 200";;
 "j8m1_2";"Ki 200";;
-
+#
 "r2y2_kai_shop";"R2Y2-G Keiun Kai (Model 11)";;
 "r2y2_kai_0";"Yokosuka Naval Arsenal | R2Y2-G Keiun Kai | Experimental Model 11";;
 "r2y2_kai_1";"R2Y2-G Keiun Kai (Model 11)";;
 "r2y2_kai_2";"R2Y2-G (Model 11)";;
-
+#
 "r2y2_v1_shop";"R2Y2-G Keiun Kai (Model 22)";;
 "r2y2_v1_0";"Yokosuka Naval Arsenal | R2Y2-G Keiun Kai  | Experimental Model 22";;
 "r2y2_v1_1";"R2Y2-G Keiun Kai (Model 22)";;
 "r2y2_v1_2";"R2Y2-G (Model 22)";;
-
+#
 "r2y2_v2_shop";"R2Y2-G Keiun Kai (Model 32)";;
 "r2y2_v2_0";"Yokosuka Naval Arsenal | R2Y2-G Keiun Kai | Experimental Model 32";;
 "r2y2_v2_1";"R2Y2-G Keiun Kai (Model 32)";;
 "r2y2_v2_2";"R2Y2-G (Model 32)";;
-
+#
 "n1k1_ja_shop";"N1K1-J Kō Shiden";;
 "n1k1_ja_0";"Kawashini Aircraft | N1K1-J Shiden | Model 11 Kō";;
 "n1k1_ja_1";"N1K1-J Kō Shiden";;
 "n1k1_ja_2";"N1K1-J Kō";;
-
+#
 "n1k2_j_shop";"N1K2-J Shiden";;
 "n1k2_j_0";"Kawashini Aircraft | N1K2-J Shiden | Model 12";;
 "n1k2_j_1";"N1K2-J Shiden";;
 "n1k2_j_2";"N1K2-J";;
-
+#
 "n1k2_jko_shop";"N1K2-J Kō Shiden";;
 "n1k2_jko_0";"Kawashini Aircraft | N1K2-J Shiden |Model 12 Kō";;
 "n1k2_jko_1";"N1K2-J Kō Shiden";;
 "n1k2_jko_2";"N1K2-J Kō";;
-
+#
 "a7m2_shop";"A7M2 Reppū";;
 "a7m2_0";"Mitsubishi Heavy Industries | A7M2 Reppū | Model 11";;
 "a7m2_1";"A7M2 Reppū";;
 "a7m2_2";"A7M2";;
-
+#
 "a6m5otsu_shop";"A6M5 Otsu Reisen";;
 "a6m5otsu_0";"Mitsubishi Heavy Industries | A6M5 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 52 Otsu";;
 "a6m5otsu_1";"A6M5 Otsu Reisen";;
 "a6m5otsu_2";"A6M5 Otsu";;
-
+#
 "a6m5hei_shop";"A6M5 Hei Reisen";;
 "a6m5hei_0";"Mitsubishi Heavy Industries | A6M5 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 52 Hei";;
 "a6m5hei_1";"A6M5 Hei Reisen";;
 "a6m5hei_2";"A6M5 Hei";;
-
+#
 "ki_61_1a_hei_shop";"Ki 61-I Hei Hien";;
 "ki_61_1a_hei_0";"Kawasaki Aircraft Industries | Ki 61-I Hien | Type 3 Fighter | Model 1 Hei";;
 "ki_61_1a_hei_1";"Ki 61-I Hei Hien";;
 "ki_61_1a_hei_2";"Ki 61-I Hei";;
-
+#
 "ki_61_1a_hei_ep_shop";"Ki 61-I Hei Hien [Tada]";;
 "ki_61_1a_hei_ep_0";"Kawasaki Aircraft Industries | Takeichi Tada's Ki 61-I Hien | Type 3 Fighter | Model 1 Hei";;
 "ki_61_1a_hei_ep_1";"Ki 61-I Hei Hien [Tada]";;
 "ki_61_1a_hei_ep_2";"Ki 61-I Hei [Tada]";;
-
+#
 "ki_84_ko_shop";"Ki 84-I Kō Hayate";;
 "ki_84_ko_0";"Nakajima Aircraft | Ki 84-I Hayate | Type 4 Fighter | Model 1 Kō";;
 "ki_84_ko_1";"Ki 84-I Kō Hayate";;
 "ki_84_ko_2";"Ki 84-I Kō";;
-
+#
 "ki_84_otsu_shop";"Ki 84-I Otsu Hayate";;
 "ki_84_otsu_0";"Nakajima Aircraft | Ki 84-I Hayate | Type 4 Fighter | Model 1 Otsu";;
 "ki_84_otsu_1";"Ki 84-I Otsu Hayate";;
 "ki_84_otsu_2";"Ki 84-I Otsu";;
-
+#
 "ki_84_hei_shop";"Ki 84-I Hei Hayate";;
 "ki_84_hei_0";"Nakajima Aircraft | Ki 84-I Hayate | Type 4 Fighter | Model 1 Hei";;
 "ki_84_hei_1";"Ki 84-I Hei Hayate";;
 "ki_84_hei_2";"Ki 84-I Hei";;
-
+#
 "j7w1_shop";"J7W1 Shinden";;
 "j7w1_0";"Naval Aviation Technology Arsenal / Kyūshū Aircraft | J7W1 Shinden | 18th Experimental Otsu Land Fighter";;
 "j7w1_1";"J7W1 Shinden";;
 "j7w1_2";"J7W1";;
-
+#
 "j2m3_shop";"J2M3 Raiden";;
 "j2m3_0";"Mitsubishi Heavy Industries | J2M3 Raiden | Model 21";;
 "j2m3_1";"J2M3 Raiden";;
 "j2m3_2";"J2M3";;
-
+#
 "j2m5_shop";"J2M5 Raiden";;
 "j2m5_0";"Mitsubishi Heavy Industries | J2M5 Raiden | Model 33";;
 "j2m5_1";"J2M5 Raiden";;
 "j2m5_2";"J2M5";;
-
+#
 "ki-83_shop";"Ki 83";;
 "ki-83_0";"Mitsubishi Heavy Industries | Ki 83";;
 "ki-83_1";"Ki 83";;
 "ki-83_2";"Ki 83";;
-
+#
 "g8n1_shop";"G8N1 Renzan";;
 "g8n1_0";"Nakajima Aircraft | G8N1 Renzan | 18th Experimental Land Attack Aircraft";;
 "g8n1_1";"G8N1 Renzan";;
 "g8n1_2";"G8N1";;
-
+#
 "a7m1_shop";"A7M1 Reppū";;
 "a7m1_0";"Mitsubishi Heavy Industries | A7M1 Reppū | 17th Experimental Kō Carrier-Based Fighter";;
 "a7m1_1";"A7M1 Reppū";;
 "a7m1_2";"A7M1";;
-
+#
 "j2m5_30mm_shop";"J2M5 Raiden (Type 5)";;
 "j2m5_30mm_0";"Mitsubishi Heavy Industries | J2M5 Raiden | Model 33 | Type 5 30mm Autocannon";;
 "j2m5_30mm_1";"J2M5 Raiden (Type 5)";;
 "j2m5_30mm_2";"J2M5 (Type 5)";;
-
+#
 "ki_87_shop";"Ki 87";;
 "ki_87_0";"Nakajima Aircraft | Ki 87";;
 "ki_87_1";"Ki 87";;
 "ki_87_2";"Ki 87";;
-
+#
 "a6m6c_shop";"A6M6 Reisen";;
 "a6m6c_0";"Mitsubishi Heavy Industries | A6M6 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 53";;
 "a6m6c_1";"A6M6 Reisen";;
 "a6m6c_2";"A6M6";;
-
+#
 "ki_94_2_shop";"Ki 94-II";;
 "ki_94_2_0";"Tachikawa Aircaft | Ki 94-II";;
 "ki_94_2_1";"Ki 94-II";;
 "ki_94_2_2";"Ki 94-II";;
-
+#
 "j6k1_shop";"J6K1 Jinpū";;
 "j6k1_0";"Kawanshini Aircraft Company | J6K1 Jinpū | 18th Experimental Kō Land Fighter";;
 "j6k1_1";"J6K1 Jinpū";;
 "j6k1_2";"J6K1";;
-
+#
 "a6m3_zero_shop";"A6M3 Reisen (Model 32)";;
 "a6m3_zero_0";"Mitsubishi Heavy Industries | A6M3 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 32";;
 "a6m3_zero_1";"A6M3 Reisen (Model 32)";;
 "a6m3_zero_2";"A6M3 (Model 32)";;
-
+#
 "a6m3_mod22_zero_shop";"A6M3 Reisen (Model 22)";;
 "a6m3_mod22_zero_0";"Mitsubishi Heavy Industries | A6M3 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 22";;
 "a6m3_mod22_zero_1";"A6M3 Reisen (Model 22)";;
 "a6m3_mod22_zero_2";"A6M3 (Model 22)";;
-
+#
 "a6m3_mod22ko_zero_shop";"A6M3 Kō Reisen";;
 "a6m3_mod22ko_zero_0";"Mitsubishi Heavy Industries | A6M3 Reisen | Type 0 Carrier Fighter ""Zero"" | Model 22 Kō";;
 "a6m3_mod22ko_zero_1";"A6M3 Kō Reisen";;
 "a6m3_mod22ko_zero_2";"A6M3 Kō";;
-
+#
 "a6m5_zero_shop";"A6M5 Reisen";;
 "a6m5_zero_0";"Mitsubishi Heavy Industries | A6M5 Reisen | Type 0 Carrier Fighter | Model 52";;
 "a6m5_zero_1";"A6M5 Reisen";;
 "a6m5_zero_2";"A6M5";;
-
+#
 "ki_43_3_otsu_shop";"Ki 43-III Otsu Hayabusa";;
 "ki_43_3_otsu_0";"Nakajima Aircraft / Tachikawa Aircraft | Ki 43-III Hayabusa | Type 1 Fighter | Model 3 Otsu";;
 "ki_43_3_otsu_1";"Ki 43-III Otsu Hayabusa";;
 "ki_43_3_otsu_2";"Ki 43-III Otsu";;
-
+#
 "ki_61_1a_tei_shop";"Ki 61-I Hei Hien";;
 "ki_61_1a_tei_0";"Kawasaki Aircraft Industries | Ki 61-I Hien | Type 3 Fighter | Model 1 Hei";;
 "ki_61_1a_tei_1";"Ki 61-I Hei Hien";;
 "ki_61_1a_tei_2";"Ki 61-I Hei";;
-
+#
 "ki_61_2_early_shop";"Ki 61-II Kai Kō Hien";;
 "ki_61_2_early_0";"Kawasaki Aircraft Industries | Ki 61-II Hien | Type 3 Fighter | Model 2 Kai Kō";;
 "ki_61_2_early_1";"Ki 61-II Kai Kō Hien";;
 "ki_61_2_early_2";"Ki 61-II Kai Kō";;
-
+#
 "ki_100_early_shop";"Ki 100-I Kō";;
 "ki_100_early_0";"Kawasaki Aircraft Industries | Ki 100-I Kō";;
 "ki_100_early_1";"Ki 100-I Kō";;
 "ki_100_early_2";"Ki 100-I Kō";;
-
+#
 "ki_108_shop";"Ki 108 Kai";;
 "ki_108_0";"Kawasaki Aircraft Industries | Ki 108 Kai";;
 "ki_108_1";"Ki 108 Kai";;
 "ki_108_2";"Ki 108 Kai";;
-
+#
 "j2m2_shop";"J2M2 Raiden";;
 "j2m2_0";"Mitsubishi Heavy Industries | J2M2 Raiden | Model 11";;
 "j2m2_1";"J2M2 Raiden";;
 "j2m2_2";"J2M2";;
-
+#
 "j5n1_shop";"J5N1 Tenrai";;
 "j5n1_0";"Nakajima Aircraft | J5N1 Tenrai | 18th Experimental Twin-Engine Land Fighter";;
 "j5n1_1";"J5N1 Tenrai";;
 "j5n1_2";"J5N1";;
-
+#
 "p1y1_mod11_shop";"P1Y1 Ginga";;
 "p1y1_mod11_0";"Nakajima Aircraft | P1Y1 Ginga | Model 11";;
 "p1y1_mod11_1";"P1Y1 Ginga";;
 "p1y1_mod11_2";"P1Y1";;
-
+#
 "b7a2_shop";"B7A1 Ryusei";;
 "b7a2_0";"Aichi Aircraft | B7A1 Ryusei | Experimental | NK9C";;
 "b7a2_1";"B7A1 Ryusei";;
 "b7a2_2";"B7A1";;
-
+#
 "b7a2_homare_23_shop";"B7A2 Ryusei Kai";;
 "b7a2_homare_23_0";"Aichi Aircraft | B7A2 Ryusei Kai | Experimental";;
 "b7a2_homare_23_1";"B7A2 Ryusei Kai";;
 "b7a2_homare_23_2";"B7A2";;
-
+#
 "ki-49_2b_shop";"Ki 49-II Otsu Donryu (1942)";;
 "ki-49_2b_0";"Nakajima Aircraft | Ki 49-II Donryu | Type 100 Heavy Bomber | Model 2 Otsu (1942)";;
 "ki-49_2b_1";"Ki 49-II Otsu Donryu (1942)";;
 "ki-49_2b_2";"Ki 49-II Otsu (1942)";;
-
+#
 "ki-49_2b_late_shop";"Ki 49-II Otsu Donryu (1943)";;
 "ki-49_2b_late_0";"Nakajima Aircraft | Ki 49-II Donryu | Type 100 Heavy Bomber | Model 2 Otsu (1943)";;
 "ki-49_2b_late_1";"Ki 49-II Otsu Donryu (1943)";;
 "ki-49_2b_late_2";"Ki 49-II Otsu (1943)";;
-
+#
 "g5n1_shop";"G5N1 Shinzan";;
 "g5n1_0";"Nakajima Aircraft | G5N1 Shinzan | 13th Experimental Land Attack Aircraft";;
 "g5n1_1";"G5N1 Shinzan";;
 "g5n1_2";"G5N1";;
-
+#
 "ki_67_1_otsu_shop";"Ki 67-I Otsu Hiryū";;
 "ki_67_1_otsu_0";"Mitsubishi Aircraft Company | Ki 67-I Hiryū  | Type 4 Heavy Bomber | Model 1 Otsu";;
 "ki_67_1_otsu_1";"Ki 67-I Otsu Hiryū";;
 "ki_67_1_otsu_2";"Ki 67-I Otsu";;
-
+#
 "ki_67_1_ko_shop";"Ki 67-I Kō Hiryū";;
 "ki_67_1_ko_0";"Mitsubishi Aircraft Company | Ki 67-I Hiryū | Type 4 Heavy Bomber | Model 1 Kō";;
 "ki_67_1_ko_1";"Ki 67-I Kō Hiryū";;
 "ki_67_1_ko_2";"Ki 67-I Kō";;
-
+#
 "ki-96_shop";"Ki 96 (No. 3)";;
 "ki-96_0";"Kawasaki Aircraft Industries | Ki 96 | Prototype No. 3";;
 "ki-96_1";"Ki 96 (No. 3)";;
 "ki-96_2";"Ki 96 (No. 3)";;
-
+#
 "ki_100_2_shop";"Ki 100-II";;
 "ki_100_2_0";"Kawasaki Aircraft Industries | Ki 100-II";;
 "ki_100_2_1";"Ki 100-II";;
 "ki_100_2_2";"Ki 100-II";;
-
+#
 "a6m2_n_zero_shop";"A6M2-N";;
 "a6m2_n_zero_0";"Nakajima Aircraft | A6M2-N | Type 2 Seaplane Fighter";;
 "a6m2_n_zero_1";"A6M2-N";;
 "a6m2_n_zero_2";"A6M2-N";;
-
+#
 "n1k1_kyuofu_shop";"N1K1 Kyōfū";;
 "n1k1_kyuofu_0";"Kawashini Aircraft | N1K1 Kyōfū";;
 "n1k1_kyuofu_1";"N1K1 Kyōfū";;
 "n1k1_kyuofu_2";"N1K1";;
-
+#
 "a6m2_mod11_shop";"A6M2 Reisen (Model 11)";;
 "a6m2_mod11_0";"Mitsubishi Heavy Industries | A6M2 Reisen | Type 0 Carrier Fighter | Model 11";;
 "a6m2_mod11_1";"A6M2 Reisen (Model 11)";;
 "a6m2_mod11_2";"A6M2 (Model 11)";;
-
+#
 "a6m2_zero_shop";"A6M2 Reisen (Model 21)";;
 "a6m2_zero_0";"Mitsubishi Heavy Industries | A6M2 Reisen | Type 0 Carrier Fighter | Model 21";;
 "a6m2_zero_1";"A6M2 Reisen (Model 21)";;
 "a6m2_zero_2";"A6M2 (Model 21)";;
-
+#
 "ki_44_1_shop";"Ki 44-I Shōki";;
 "ki_44_1_0";"Nakajima Aircraft Company | Ki 44-I Shōki | Type 2 Fighter | Model 1";;
 "ki_44_1_1";"Ki 44-I Shōki";;
 "ki_44_1_2";"Ki 44-I";;
-
+#
 "ki_44_1_ep_shop";"Ki 44-I Shōki (47th FS)";;
 "ki_44_1_ep_0";"Nakajima Aircraft Company | Ki 44-I Shōki | Type 2 Fighter | Model 1 | Independent 47th Flight Squadron";;
 "ki_44_1_ep_1";"Ki 44-I Shōki (47th FS)";;
 "ki_44_1_ep_2";"Ki 44-I (47th FS)";;
-
+#
 "ki_44_2_otsu_shop";"Ki 44-II Otsu Shōki";;
 "ki_44_2_otsu_0";"Nakajima Aircraft Company | Ki 44-II Shōki | Type 2 Fighter | Model 2 Otsu";;
 "ki_44_2_otsu_1";"Ki 44-II Otsu Shōki";;
 "ki_44_2_otsu_2";"Ki 44-II Otsu";;
-
+#
 "ki_44_2_hei_shop";"Ki 44-II Hei Shōki";;
 "ki_44_2_hei_0";"Nakajima Aircraft Company | Ki 44-II Shōki | Type 2 Fighter | Model 2 Hei";;
 "ki_44_2_hei_1";"Ki 44-II Hei Shōki";;
 "ki_44_2_hei_2";"Ki 44-II Hei";;
-
+#
 "ki_61_1a_ko_shop";"Ki 61-I Kō Hien";;
 "ki_61_1a_ko_0";"Kawasaki Aircraft Industries | Ki 61-I Hien | Type 3 Fighter | Model 1 Kō";;
 "ki_61_1a_ko_1";"Ki 61-I Kō Hien";;
 "ki_61_1a_ko_2";"Ki 61-I Kō";;
-
+#
 "ki_61_1a_otsu_shop";"Ki 61-I Otsu Hien";;
 "ki_61_1a_otsu_0";"Kawasaki Aircraft Industries | Ki 61-I Hien | Type 3 Fighter | Model 1 Otsu ";;
 "ki_61_1a_otsu_1";"Ki 61-I Otsu Hien";;
 "ki_61_1a_otsu_2";"Ki 61-I Otsu";;
-
+#
 "j1n1_mod11_early_shop";"J1N1";;
 "j1n1_mod11_early_0";"Nakajima Aircraft | J1N1 | 13th Experimental Twin-Engine Land Fighter";;
 "j1n1_mod11_early_1";"J1N1";;
 "j1n1_mod11_early_2";"J1N1";;
-
+#
 "ki_102_otsu_shop";"Ki 102 Otsu";;
 "ki_102_otsu_0";"Kawasaki Aircraft Industries | Ki 102 Otsu | Type 5 Twin-Engine Attack Aircraft";;
 "ki_102_otsu_1";"Ki 102 Otsu";;
 "ki_102_otsu_2";"Ki 102 Otsu";;
-
+#
 "b6n2_shop";"B6N2 Tenzan";;
 "b6n2_0";"Nakajima Aircraft | B6N2 Tenzan | Model 12";;
 "b6n2_1";"B6N2 Tenzan";;
 "b6n2_2";"B6N2";;
-
+#
 "b6n2a_shop";"B6N2 Kō Tenzan";;
 "b6n2a_0";"Nakajima Aircraft | B6N2 Tenzan | Model 12 Kō";;
 "b6n2a_1";"B6N2 Kō Tenzan";;
 "b6n2a_2";"B6N2 Kō";;
-
+#
 "d4y1_shop";"D4Y1 Suisei";;
 "d4y1_0";"Aichi Aircraft | D4Y1 Suisei | Model 11";;
 "d4y1_1";"D4Y1 Suisei";;
 "d4y1_2";"D4Y1";;
-
+#
 "d4y2_shop";"D4Y2 Suisei";;
 "d4y2_0";"Aichi Aircraft | D4Y2 Suisei | Model 12";;
 "d4y2_1";"D4Y2 Suisei";;
 "d4y2_2";"D4Y2";;
-
+#
 "d4y3_shop";"D4Y3 Kō Suisei";;
 "d4y3_0";"Aichi Aircraft | D4Y3 Suisei | Model 12 Kō";;
 "d4y3_1";"D4Y3 Kō Suisei";;
 "d4y3_2";"D4Y3 Kō";;
-
+#
 "g4m1_shop";"G4M1";;
 "g4m1_0";"Mitsubishi Heavy Industries | G4M1 | Type 1 Land Attack Aircraft | Model 11";;
 "g4m1_1";"G4M1";;
 "g4m1_2";"G4M1";;
-
+#
 "h8k2_shop";"H8K2";;
 "h8k2_0";"Kawashini Aircraft | H8K2 | Type 2 Flying Boat | Model 12";;
 "h8k2_1";"H8K2";;
 "h8k2_2";"H8K2";;
-
+#
 "ki-49_1_shop";"Ki 49-I Donryu";;
 "ki-49_1_0";"Nakajima Aircraft | Ki 49-I Donryu | Type 100 Heavy Bomber | Model 1 Otsu";;
 "ki-49_1_1";"Ki 49-I Donryu";;
 "ki-49_1_2";"Ki 49-I";;
-
+#
 "ki-49_2a_shop";"Ki 49-II Kō Donryu";;
 "ki-49_2a_0";"Nakajima Aircraft | Ki 49-II Donryu | Type 100 Heavy Bomber | Model 2 Kō";;
 "ki-49_2a_1";"Ki 49-II Kō Donryu";;
 "ki-49_2a_2";"Ki 49-II Kō";;
-
+#
 "a7he1_shop";"A7He1";;
 "a7he1_0";"Heinkel Flugzeugwerke | A7He1 | Heinkel Model 112 Land Fighter";;
 "a7he1_1";"A7He1";;
 "a7he1_2";"A7He1";;
-
+#
 "h8k3_shop";"H8K3";;
 "h8k3_0";"Kawashini Aircraft | H8K3 | Type 2 Flying Boat | Model 22";;
 "h8k3_1";"H8K3";;
 "h8k3_2";"H8K3";;
-
+#
 "ki_48_2_otsu_shop";"Ki 48-II Otsu";;
 "ki_48_2_otsu_0";"Kawasaki Aircraft Industries | Ki 48-II Otsu | Type 99 Twin-Engine Light Bomber | Model 2 Otsu";;
 "ki_48_2_otsu_1";"Ki 48-II Otsu";;
 "ki_48_2_otsu_2";"Ki 48-II Otsu";;
-
+#
 "ki_48_2_otsu_event_shop";"Ki 48-II Otsu";;
 "ki_48_2_otsu_event_0";"Kawasaki Aircraft Industries | Ki 48-II Otsu | Type 99 Twin-Engine Light Bomber | Model 2 Otsu";;
 "ki_48_2_otsu_event_1";"Ki 48-II Otsu";;
 "ki_48_2_otsu_event_2";"Ki 48-II Otsu";;
-
+#
 "ki_21_1hei_shop";"Ki 21-I Hei";;
 "ki_21_1hei_0";"Mitsubishi Heavy Industries | Ki 21-I Hei | Type 97 Heavy Bomber | Model 1 Hei";;
 "ki_21_1hei_1";"Ki 21-I Hei";;
 "ki_21_1hei_2";"Ki 21-I Hei";;
-
+#
 "f4u-1a_japan_shop";"▅F4U-1A Korusea";;
 "f4u-1a_japan_0";"▅Vought-Sikorsky Aircraft | F4U-1A Korusea ""Shikorusukī""";;
 "f4u-1a_japan_1";"▅F4U-1A Korusea";;
 "f4u-1a_japan_2";"▅F4U-1A";;
-
+#
 "f1m2_shop";"F1M2";;
 "f1m2_0";"Mitsubishi Heavy Industries | F1M2 | Type 0 Observation Aircraft";;
 "f1m2_1";"F1M2";;
 "f1m2_2";"F1M2";;
-
+#
 "a5m4_shop";"A5M4";;
 "a5m4_0";"Mitsubishi Heavy Industries | A5M4 | Type 96 No. 4 Carrier Fighter | Model 4";;
 "a5m4_1";"A5M4";;
 "a5m4_2";"A5M4";;
-
+#
 "ki_10_1_shop";"Ki 10-I";;
 "ki_10_1_0";"Kawasaki Aircraft Industries | Ki 10-I | Type 95 Fighter | Model 1";;
 "ki_10_1_1";"Ki 10-I";;
 "ki_10_1_2";"Ki 10-I";;
-
+#
 "ki_10_1_commander_shop";"Ki 10-I (1st FS)";;
 "ki_10_1_commander_0";"Kawasaki Aircraft Industries | Ki 10-I | Type 95 Fighter | Model 1 | 1st Flight Squadron";;
 "ki_10_1_commander_1";"Ki 10-I (1st FS)";;
 "ki_10_1_commander_2";"Ki 10-I (1st FS)";;
-
+#
 "ki_10_2_shop";"Ki 10-II";;
 "ki_10_2_0";"Kawasaki Aircraft Industries | Ki 10-II | Type 95 Fighter | Model 2";;
 "ki_10_2_1";"Ki 10-II";;
 "ki_10_2_2";"Ki 10-II";;
-
+#
 "ki_10_2_commander_shop";"Ki 10-II (77th FS)";;
 "ki_10_2_commander_0";"Kawasaki Aircraft Industries | Ki 10-II | Type 95 Fighter | Model 2 | 77th Flight Squadron";;
 "ki_10_2_commander_1";"Ki 10-II (77th FS)";;
 "ki_10_2_commander_2";"Ki 10-II (77th FS)";;
-
+#
 "ki-27_otsu_shop";"Ki 27 Otsu";;
 "ki-27_otsu_0";"Nakajima Aircraft | Ki 27 | Type 97 Fighter Otsu";;
 "ki-27_otsu_1";"Ki 27 Otsu";;
 "ki-27_otsu_2";"Ki 27 Otsu";;
-
+#
 "ki-27_otsu_ep_shop";"Ki 27 Otsu (4th FS)";;
 "ki-27_otsu_ep_0";"Nakajima Aircraft | Ki 27 | Type 97 Fighter Otsu | 4th Flight Squadron";;
 "ki-27_otsu_ep_1";"Ki 27 Otsu (4th FS)";;
 "ki-27_otsu_ep_2";"Ki 27 Otsu (4th FS)";;
-
+#
 "ki_43_1_shop";"Ki 43-I Hei Hayabusa";;
 "ki_43_1_0";"Nakajima Aircraft | Ki 43-I Hayabusa | Type 1 Fighter | Model 1 Hei";;
 "ki_43_1_1";"Ki 43-I Hei Hayabusa";;
 "ki_43_1_2";"Ki 43-I Hei";;
-
+#
 "ki_43_2_shop";"Ki 43-II Otsu Hayabusa";;
 "ki_43_2_0";"Nakajima Aircraft | Ki 43-II Hayabusa | Type 1 Fighter | Model 2 Otsu";;
 "ki_43_2_1";"Ki 43-II Otsu Hayabusa";;
 "ki_43_2_2";"Ki 43-II Otsu";;
-
+#
 "ki-45_tei_shop";"Ki 45 Kai Hei Toryu (Tei)";;
 "ki-45_tei_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Hei  | Tei Equipment";;
 "ki-45_tei_1";"Ki 45 Kai Hei Toryu (Tei)";;
 "ki-45_tei_2";"Ki 45 Kai Hei (Tei)";;
-
+#
 "ki-45_otsu_shop";"Ki 45 Kai Otsu Toryu";;
 "ki-45_otsu_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Otsu";;
 "ki-45_otsu_1";"Ki 45 Kai Otsu Toryu";;
 "ki-45_otsu_2";"Ki 45 Kai Otsu";;
-
+#
 "ki-45_ko_tei_shop";"Ki 45 Kai Kō Toryu (Tei)";;
 "ki-45_ko_tei_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Kō  | Tei Equipment";;
 "ki-45_ko_tei_1";"Ki 45 Kai Kō Toryu (Tei)";;
 "ki-45_ko_tei_2";"Ki 45 Kai Kō (Tei)";;
-
+#
 "ki-45_hei_shop";"Ki 45 Kai Hei Toryu";;
 "ki-45_hei_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Hei";;
 "ki-45_hei_1";"Ki 45 Kai Hei Toryu";;
 "ki-45_hei_2";"Ki 45 Kai Hei";;
-
+#
 "ki-45_hei_tei_shop";"Ki 45 Kai Hei Toryu (Tei)";;
 "ki-45_hei_tei_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Hei | Tei Equipment";;
 "ki-45_hei_tei_1";"Ki 45 Kai Hei Toryu (Tei)";;
 "ki-45_hei_tei_2";"Ki 45 Kai Hei (Tei)";;
-
+#
 "ki-45_ko_shop";"Ki 45 Kai Kō Toryu";;
 "ki-45_ko_0";"Kawasaki Aircraft Industries | Ki 45 Toryu | Type 2 Two-Seat Fighter | Kai Kō";;
 "ki-45_ko_1";"Ki 45 Kai Kō Toryu";;
 "ki-45_ko_2";"Ki 45 Kai Kō";;
-
+#
 "ki_109_shop";"Ki 109";;
 "ki_109_0";"Mitsubishi Heavy Industries | Ki 109";;
 "ki_109_1";"Ki 109";;
 "ki_109_2";"Ki 109";;
-
+#
 "b5n2_shop";"B5N2";;
 "b5n2_0";"Nakajima Aircraft | B5N2 | Type 97 Carrier Attack Bomber | Model 12";;
 "b5n2_1";"B5N2";;
 "b5n2_2";"B5N2";;
-
+#
 "d3a1_shop";"D3A1";;
 "d3a1_0";"Aichi Aircraft | D3A1 | Type 99 Carrier Bomber | Model 11";;
 "d3a1_1";"D3A1";;
 "d3a1_2";"D3A1";;
-
+#
 "b6n1_shop";"B6N1 Tenzan";;
 "b6n1_0";"Nakajima Aircraft | B6N1 Tenzan | Model 11";;
 "b6n1_1";"B6N1 Tenzan";;
 "b6n1_2";"B6N1";;
-
+#
 "ki_32_shop";"Ki 32";;
 "ki_32_0";"Kawasaki Aircraft Industries | Ki 32 | Type 98 Light Bomber";;
 "ki_32_1";"Ki 32";;
 "ki_32_2";"Ki 32";;
-
+#
 "ki_21_1ko_shop";"Ki 21-I Kō";;
 "ki_21_1ko_0";"Mitsubishi Heavy Industries | Ki 21-I | Type 97 Heavy Bomber | Model 1 Kō";;
 "ki_21_1ko_1";"Ki 21-I Kō";;
 "ki_21_1ko_2";"Ki 21-I Kō";;
-
+#
 "h6k4_shop";"H6K4";;
 "h6k4_0";"Kawashini Aircraft | H6K4 | Type 97 Flying Boat | Model 22";;
 "h6k4_1";"H6K4";;
 "h6k4_2";"H6K4";;
-
+#
 "a5m4_hagiri_shop";"A5M4 [Hagiri]";;
 "a5m4_hagiri_0";"Mitsubishi Heavy Industries | Matsuo Hagiri's A5M4 | Type 96 No. 4 Carrier Fighter | Model 4";;
 "a5m4_hagiri_1";"A5M4 [Hagiri]";;
 "a5m4_hagiri_2";"A5M4 [Hagiri]";;
-
+#
 "bf-109e-3_japan_shop";"▅Bf 109 E-7 Messer";;
 "bf-109e-3_japan_0";"Messerschmitt AG | ▅Bf 109 E-7 Messer";;
 "bf-109e-3_japan_1";"▅Bf 109 E-7 Messer";;
 "bf-109e-3_japan_2";"▅Bf 109 E-7";;
-
+#
 "f4u-1a_japan_shop";"▅F4U-1A Corsair";;
 "f4u-1a_japan_0";"Chance Vought Corporation | ▅F4U-1A Corsair";;
 "f4u-1a_japan_1";"▅F4U-1A Corsair";;
 "f4u-1a_japan_2";"▅F4U-1A";;
-
+#
 "p-51c-11-nt_japan_shop";"▅P-51C-11 Mustang";;
 "p-51c-11-nt_japan_0";"North American Aviation | ▅P-51C-11 Mustang | Block 11";;
 "p-51c-11-nt_japan_1";"▅P-51C-11 Mustang";;
 "p-51c-11-nt_japan_2";"▅P-51C-11";;
-
+#
 "sb2c_5_thailand_shop";"▄B.J.3 Helldiver";;
 "sb2c_5_thailand_0";"Curtiss-Wright Corporation | ▄B.J.3 | SB2C-5 Helldiver";;
 "sb2c_5_thailand_1";"▄B.J.3 Helldiver";;
 "sb2c_5_thailand_2";"▄B.J.3";;
-
+#
 "b-17e_japan_shop";"▅B-17E Flying Fortress";;
 "b-17e_japan_0";"▅Boeing Airplane Company | B-17E Flying Fortress";;
 "b-17e_japan_1";"▅B-17E Flying Fortress";;
 "b-17e_japan_2";"▅B-17E";;
-
+#
 "f-84g_thailand_shop";"▄B.Kh.16 Thunderjet";;
 "f-84g_thailand_0";"Republic Aviation Corporation | ▄B.Kh.16 | F-84G-21 Thunderjet";;
 "f-84g_thailand_1";"▄B.Kh.16 Thunderjet";;
 "f-84g_thailand_2";"▄B.Kh.16";;
-
+#
 "f-86f-30_japan_shop";"▅F-86F-30 Sabre";;
 "f-86f-30_japan_0";"North American Aviation | ▅F-86F-30 Sabre | Block 30";;
 "f-86f-30_japan_1";"▅F-86F-30 Sabre";;
 "f-86f-30_japan_2";"▅F-86F-30";;
-
+#
 "f-86f-40_japan_shop";"▅F-86F-40 Sabre";;
 "f-86f-40_japan_0";"North American Aviation | ▅F-86F-40 Sabre | Block 40";;
 "f-86f-40_japan_1";"▅F-86F-40 Sabre";;
 "f-86f-40_japan_2";"▅F-86F-40";;
-
+#
 "f-86f-40_japan_blue_impulse_shop";"▅F-86F-40 Sabre (6 SQN)";;
 "f-86f-40_japan_blue_impulse_0";"North American Aviation | ▅F-86F-40 Sabre | Block 40 | 6 Squadron 8th Air Wing";;
 "f-86f-40_japan_blue_impulse_1";"▅F-86F-40 Sabre (6 SQN)";;
 "f-86f-40_japan_blue_impulse_2";"▅F-86F-40 (6 SQN)";;
-
+#
 "alpha_jet_a_thailand_shop";"▄B.J.7 Alpha Jet (1999)";;
 "alpha_jet_a_thailand_0";"Dassault/Dornier | ▄B.J.7 | Alpha Jet A (1999)";;
 "alpha_jet_a_thailand_1";"▄B.J.7 Alpha Jet (1999)";;
 "alpha_jet_a_thailand_2";"▄B.J.7 (1999)";;
-
+#
 "alpha_jet_th_phase_1_shop";"▄B.J.7 Alpha Jet (2004)";;
 "alpha_jet_th_phase_1_0";"Dassault/Dornier | ▄B.J.7 | Alpha Jet TH, Phase 1 (2004)";;
 "alpha_jet_th_phase_1_1";"▄B.J.7 Alpha Jet (2004)";;
 "alpha_jet_th_phase_1_2";"▄B.J.7 (2004)";;
-
+#
 "av_8s_thailand_shop";"▄B.KhL.1 Matador (1973)";;
 "av_8s_thailand_0";"Hawker Siddeley Group, Ltd. | ▄B.KhL.1 | AV-8S Matador (1973)";;
 "av_8s_thailand_1";"▄B.KhL.1 Matador (1973)";;
 "av_8s_thailand_2";"▄B.KhL.1 (1973)";;
-
+#
 "t2_early_shop";"T-2 (1975)";;
 "t2_early_0";"Mitsubishi Heavy Industries, Ltd. | T-2 | Zenki-gata (1975)";;
 "t2_early_1";"T-2 (1975)";;
 "t2_early_2";"T-2 (1975)";;
-
+#
 "t2_shop";"T-2 (1979)";;
 "t2_0";"Mitsubishi Heavy Industries, Ltd. | T-2 | Kōki-gata (1979)";;
 "t2_1";"T-2 (1979)";;
 "t2_2";"T-2 (1979)";;
-
+#
 "f1_shop";"F-1";;
 "f1_0";"Mitsubishi Heavy Industries, Ltd. | F-1";;
 "f1_1";"F-1";;
 "f1_2";"F-1";;
-
+#
 "f-104j_shop";"▅F-104J Starfighter";;
 "f-104j_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-104J Starfighter";;
 "f-104j_1";"▅F-104J Starfighter";;
 "f-104j_2";"▅F-104J";;
-
+#
 "a_7e_thailand_shop";"▄B.HT.1 Corsair II";;
 "a_7e_thailand_0";"LTV Aerospace Corporation | ▄B.HT.1 | A-7E Corsair II";;
 "a_7e_thailand_1";"▄B.HT.1 Corsair II";;
 "a_7e_thailand_2";"▄B.HT.1";;
-
+#
 "f-5a_thailand_shop";"▄B.Kh.18 Freedom Fighter";;
 "f-5a_thailand_0";"Northrop Corporation | ▄B.Kh.18 | F-5A Freedom Fighter";;
 "f-5a_thailand_1";"▄B.Kh.18 Freedom Fighter";;
 "f-5a_thailand_2";"▄B.Kh.18";;
-
+#
 "f-5e_fcu_thailand_shop";"▄B.Kh.18Kh Tigris (1988)";;
 "f-5e_fcu_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5T Tigris | First Capability Upgrade (1988)";;
 "f-5e_fcu_thailand_1";"▄B.Kh.18Kh Tigris (1988)";;
 "f-5e_fcu_thailand_2";"▄B.Kh.18Kh (1988)";;
-
+#
 "f-5t_thailand_shop";"▄B.Kh.18Kh Tigris (2003)";;
 "f-5t_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5T Tigris | Second Capability Upgrade (2003)";;
 "f-5t_thailand_1";"▄B.Kh.18Kh Tigris (2003)";;
 "f-5t_thailand_2";"▄B.Kh.18Kh (2003)";;
-
+#
 "av_8s_late_thailand_shop";"▄B.KhL.1 Matador (1998)";;
 "av_8s_late_thailand_0";"Hawker Siddeley Group, Ltd. | ▄B.KhL.1 | AV-8S Matador (1998)";;
 "av_8s_late_thailand_1";"▄B.KhL.1 Matador (1998)";;
 "av_8s_late_thailand_2";"▄B.KhL.1 (1998)";;
-
+#
 "f-4ej_shop";"▅F-4EJ Phantom II";;
 "f-4ej_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-4EJ Phantom II";;
 "f-4ej_1";"▅F-4EJ Phantom II";;
 "f-4ej_2";"▅F-4EJ";;
-
+#
 "f-4ej_adtw_shop";"▅F-4EJ Phantom II (ADTW)";;
 "f-4ej_adtw_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-4EJ Phantom II | Air Development and Test Wing";;
 "f-4ej_adtw_1";"▅F-4EJ Phantom II (ADTW)";;
 "f-4ej_adtw_2";"▅F-4EJ (ADTW)";;
-
+#
 "f_16a_block_15_ocu_thailand_shop";"▄B.Kh.19 Viper";;
 "f_16a_block_15_ocu_thailand_0";"General Dynamics Corporation | ▄B.Kh.19 | F-16A-15OCU Viper | Mid-Life Update (2010)";;
 "f_16a_block_15_ocu_thailand_1";"▄B.Kh.19 Viper";;
 "f_16a_block_15_ocu_thailand_2";"▄B.Kh.19";;
-
+#
 "saab_jas39c_thailand_shop";"▄B.Kh.20 Gripen C";;
 "saab_jas39c_thailand_0";"Saab AB | ▄B.Kh.20 | JAS 39C Gripen C";;
 "saab_jas39c_thailand_1";"▄B.Kh.20 Gripen C";;
 "saab_jas39c_thailand_2";"▄B.Kh.20";;
-
+#
 "f-4ej_kai_shop";"▅F-4EJ Kai Phantom II";;
 "f-4ej_kai_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-4EJ Kai Phantom II";;
 "f-4ej_kai_1";"▅F-4EJ Kai Phantom II";;
 "f-4ej_kai_2";"▅F-4EJ Kai";;
-
+#
 "f_16aj_shop";"▅YF-16AJ Fighting Falcon";;
 "f_16aj_0";"General Dynamics Corporation | ▅YF-16AJ Fighting Falcon | 1975 F-X Proposal";;
 "f_16aj_1";"▅YF-16AJ Fighting Falcon";;
 "f_16aj_2";"▅YF-16AJ";;
-
+#
 "f_15j_shop";"▅F-15J Īguru";;
 "f_15j_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-15J Īguru | Peace Eagle Program";;
 "f_15j_1";"▅F-15J Īguru";;
 "f_15j_2";"▅F-15J";;
-
+#
 "f_15j_kai_shop";"▅F-15MJ Īguru";;
 "f_15j_kai_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-15MJ Īguru ""J-MSIP"" | Japan-Multi-Stage Improvement Program | Mid-Term Defense Program (2004)";;
 "f_15j_kai_1";"▅F-15MJ Īguru";;
 "f_15j_kai_2";"▅F-15MJ";;
-
+#
 "f_2a_shop";"F-2A Viper Zero";;
 "f_2a_0";"Mitsubishi Heavy Industries, Ltd. | F-2A Viper Zero";;
 "f_2a_1";"F-2A Viper Zero";;
 "f_2a_2";"F-2A";;
-
+#
 "f_2a_adtw_shop";"XF-2A Viper Zero";;
 "f_2a_adtw_0";"Mitsubishi Heavy Industries, Ltd. | XF-2A Viper Zero | 1995 FS-X Prototype | Air Development and Test Wing";;
 "f_2a_adtw_1";"XF-2A Viper Zero";;
 "f_2a_adtw_2";"XF-2A";;
-
+#
 "f-5th_thailand_shop";"▄B.Kh.18Kh Super Tigris (2014)";;
 "f-5th_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5TH Super Tigris | Third Capability Upgrade (2014)";;
 "f-5th_thailand_1";"▄B.Kh.18Kh Super Tigris (2014)";;
 "f-5th_thailand_2";"▄B.Kh.18Kh (2014)";;
-
+#
 "shop/group/f-86_japan_group";"▅F-86F Sabre";;
 "shop/group/f-86_japan_group";"▅F-86F Sabre";;
 "shop/group/r2y2_group";"R2Y2-G Keiun Kai";;
@@ -678,3 +677,15 @@ noverify>";"<English>";
 "shop/group/ki-43_group";"Ki 43-I/II";;
 "shop/group/ki-45_group";"Ki 45 Kai Kō/Hei";;
 "shop/group/ki-45_eraly_group";"Ki 45 Kai Hei (Tei)/Otsu";;
+#
+f_111f_japan_killstreak_shop;☢F-111F Aardvark;;
+f_111f_japan_killstreak_0;General Dynamics Corporation | ☢F-111F Aardvark;;
+f_111f_japan_killstreak_1;☢F-111F Aardvark;;
+f_111f_japan_killstreak_2;☢F-111F;;
+#
+#helicopters
+#
+"ah_64e_indonesia_shop";"◥AH-64E Guardian Apache (v6)";;
+"ah_64e_indonesia_0";"Boeing Defense, Space & Security | ◥Helicopter, Attack, AH-64E Guardian Apache | Capability Version 6";;
+"ah_64e_indonesia_1";"◥AH-64E Guardian Apache (v6)";;
+"ah_64e_indonesia_2";"◥AH-64E (v6)";;

--- a/Mod Files/syrup_units_usa.csv
+++ b/Mod Files/syrup_units_usa.csv
@@ -1,946 +1,956 @@
-"<ID|readonly|
-noverify>";"<English>";
-
-//Aircraft
+"<ID|readonly|noverify>";"<English>";;
+#just learned that Edit CSV doesn't automatically put quotes around stuff.
+#so some stuff will have quotes like in Gaijin's files, some wont. sorry again, addy. -maple (11/13/2025)
+#Aircraft
 "p-26a_33_shop";"P-26A-33 Peashooter";;
 "p-26a_33_0";"Boeing Airplane Company | P-26A-33 Peashooter | Block 33";;
 "p-26a_33_1";"P-26A-33 Peashooter";;
 "p-26a_33_2";"P-26A-33";;
-
+#
 "p-26a_34_shop";"P-26A-34 Peashooter";;
 "p-26a_34_0";"Boeing Airplane Company | P-26A-34 Peashooter | Block 34";;
 "p-26a_34_1";"P-26A-34 Peashooter";;
 "p-26a_34_2";"P-26A-34";;
-
+#
 "p-26a_34_m2_shop";"P-26A-34-M2 Peashooter";;
 "p-26a_34_m2_0";"Boeing Airplane Company | P-26A-34 Peashooter | Block 34, M2 Browning Modification";;
 "p-26a_34_m2_1";"P-26A-34-M2 Peashooter";;
 "p-26a_34_m2_2";"P-26A-34-M2";;
-
+#
 "p-26a_35_shop";"P-26A-35 Peashooter";;
 "p-26a_35_0";"Boeing Airplane Company | P-26A-35 Peashooter | Block 35";;
 "p-26a_35_1";"P-26A-35 Peashooter";;
-"p-26a_35_2";"P-26A-35";
-
+"p-26a_35_2";"P-26A-35";;
+#
 "p-26b_35_shop";"P-26B-35 Peashooter";;
 "p-26b_35_0";"Boeing Airplane Company | P-26B-35 Peashooter | Block 35";;
 "p-26b_35_1";"P-26B-35 Peashooter";;
 "p-26b_35_2";"P-26B-35";;
-
+#
 "p-36a_shop";"P-36A Hawk";;
 "p-36a_0";"Curtiss-Wright Corporation | P-36A Hawk";;
 "p-36a_1";"P-36A Hawk";;
 "p-36a_2";"P-36A";;
-
+#
 "p-36a_rasmussen_shop";"P-36A Hawk [Rasmussen]";;
 "p-36a_rasmussen_0";"Curtiss-Wright Corporation | Rasmussen's P-36A Hawk";;
 "p-36a_rasmussen_1";"P-36A Hawk [Rasmussen]";;
 "p-36a_rasmussen_2";"P-36A";;
-
+#
 "p-36a_brown_shop";"P-36A Hawk [Brown]";;
 "p-36a_brown_0";"Curtiss-Wright Corporation | Brown's P-36A Hawk";;
 "p-36a_brown_1";"P-36A Hawk [Brown]";;
 "p-36a_brown_2";"P-36A";;
-
+#
 "p-36c_shop";"P-36C Hawk";;
 "p-36c_0";"Curtiss-Wright Corporation | P-36C Hawk";;
 "p-36c_1";"P-36C Hawk";;
 "p-36c_2";"P-36C";;
-
+#
 "p-36c_rb_shop";"○P-36C Hawk";;
 "p-36c_rb_0";"○Curtiss-Wright Corporation | TheRussianBadger's P-36C Hawk";;
 "p-36c_rb_1";"○P-36C Hawk";;
 "p-36c_rb_2";"○P-36C";;
-
+#
 "bf2c_1_shop";"BF2C-1 Goshawk";;
 "bf2c_1_0";"Curtiss Aeroplane and Motor Company | BF2C-1 Goshawk";;
 "bf2c_1_1";"BF2C-1 Goshawk";;
 "bf2c_1_2";"BF2C-1";;
-
+#
 "f3f-2_shop";"F3F-2 Gulfhawk";;
 "f3f-2_0";"Grumman Aircraft Engineering Corporation | F3F-2 Gulfhawk";;
 "f3f-2_1";"F3F-2 Gulfhawk";;
 "f3f-2_2";"F3F-2";;
-
+#
 "f3f-2_galer_shop";"F3F-2 Gulfhawk [Galer]";;
 "f3f-2_galer_0";"Grumman Aircraft Engineering Corporation | Galer's F3F-2 Gulfhawk";;
 "f3f-2_galer_1";"F3F-2 Gulfhawk [Galer]";;
 "f3f-2_galer_2";"F3F-2";;
-
+#
 "f2a-1_shop";"F2A-1 Buffalo";;
 "f2a-1_0";"Brewster Aeronautical Corporation | F2A-1 Buffalo";;
 "f2a-1_1";"F2A-1 Buffalo";;
 "f2a-1_2";"F2A-1";;
-
+#
 "f2a-1_thach_shop";"F2A-1 Buffalo [Thach]";;
 "f2a-1_thach_0";"Brewster Aeronautical Corporation | John Thach's F2A-1 Buffalo";;
 "f2a-1_thach_1";"F2A-1 Buffalo [Thach]";;
 "f2a-1_thach_2";"F2A-1";;
-
+#
 "b_10b_shop";"B-10B (Model 139)";;
 "b_10b_0";"Martin Company | B-10B (Model 139)";;
 "b_10b_1";"B-10B (Model 139)";;
 "b_10b_2";"B-10B";;
-
+#
 "os2u_1_shop";"OS2U-1 Kingfisher";;
 "os2u_1_0";"Chance Vought Corporation | OS2U-1 Kingfisher";;
 "os2u_1_1";"OS2U-1 Kingfisher";;
 "os2u_1_2";"OS2U-1";;
-
+#
 "os2u_1_naval_shop";"OS2U-1 Kingfisher";;
 "os2u_1_naval_0";"Chance Vought Corporation | OS2U-1 Kingfisher";;
 "os2u_1_naval_1";"OS2U-1 Kingfisher";;
 "os2u_1_naval_2";"OS2U-1";;
-
+#
 "os2u_3_shop";"OS2U-3 Kingfisher";;
 "os2u_3_0";"Chance Vought Corporation | OS2U-3 Kingfisher";;
 "os2u_3_1";"OS2U-3 Kingfisher";;
 "os2u_3_2";"OS2U-3";;
-
+#
 "sb2u-3_shop";"SB2U-3 Vindicator";;
 "sb2u-3_0";"Chance Vought Corporation | SB2U-3 Vindicator";;
 "sb2u-3_1";"SB2U-3 Vindicator";;
 "sb2u-3_2";"SB2U-3";;
-
+#
 "sb2u-2_shop";"SB2U-2 Vindicator";;
 "sb2u-2_0";"Chance Vought Corporation | SB2U-2 Vindicator";;
 "sb2u-2_1";"SB2U-2 Vindicator";;
 "sb2u-2_2";"SB2U-2";;
-
+#
 "tbf-1c_shop";"TBF-1C Avenger";;
 "tbf-1c_0";"Grumman Aircraft Engineering Corporation | TBF-1C Avenger";;
 "tbf-1c_1";"TBF-1C Avenger";;
 "tbf-1c_2";"TBF-1C";;
-
+#
 "sbd-3_shop";"SBD-3 Dauntless";;
 "sbd-3_0";"Douglas Aircraft Company | SBD-3 Dauntless";;
 "sbd-3_1";"SBD-3 Dauntless";;
 "sbd-3_2";"SBD-3";;
-
+#
 "tbd-1_1938_shop";"TBD-1 Devastator";;
 "tbd-1_1938_0";"Douglas Aircraft Company | TBD-1 Devastator";;
 "tbd-1_1938_1";"TBD-1 Devastator";;
 "tbd-1_1938_2";"TBD-1";;
-
+#
 "b_18a_shop";"B-18A Bolo";;
 "b_18a_0";"Douglas Aircraft Company | B-18A Bolo";;
 "b_18a_1";"B-18A Bolo";;
 "b_18a_2";"B-18A";;
-
+#
 "pby-5_shop";"PBY-5 Catalina";;
 "pby-5_0";"Consolidated Aircraft Corporation | PBY-5 Catalina";;
 "pby-5_1";"PBY-5 Catalina";;
 "pby-5_2";"PBY-5";;
-
+#
 "pby-5a_shop";"PBY-5A Catalina";;
 "pby-5a_0";"Consolidated Aircraft Corporation | PBY-5A Catalina";;
 "pby-5a_1";"PBY-5A Catalina";;
 "pby-5a_2";"PBY-5A";;
-
+#
 "pbm_1_shop";"PBM-1 Mariner";;
 "pbm_1_0";"Martin Company | PBM-1 Mariner";;
 "pbm_1_1";"PBM-1 Mariner";;
 "pbm_1_2";"PBM-1";;
-
+#
 "pbm_3_shop";"PBM-3 Mariner";;
 "pbm_3_0";"Martin Company | PBM-3 Mariner";;
 "pbm_3_1";"PBM-3 Mariner";;
 "pbm_3_2";"PBM-3";;
-
+#
 "p-400_shop";"P-400 Airacobra";;
 "p-400_0";"Bell Aircraft Corporation | P-400 Airacobra";;
 "p-400_1";"P-400 Airacobra";;
 "p-400_2";"P-400";;
-
+#
 "p-38e_shop";"P-38E Lightning";;
 "p-38e_0";"Lockheed Corporation | P-38E Lightning";;
 "p-38e_1";"P-38E Lightning";;
 "p-38e_2";"P-38E";;
-
+#
 "yp-38_shop";"YP-38 Lightning";;
 "yp-38_0";"Lockheed Corporation | YP-38 Lightning";;
 "yp-38_1";"YP-38 Lightning";;
 "yp-38_2";"YP-38";;
-
+#
 "p-38g_shop";"P-38G-1 Lightning";;
 "p-38g_0";"Lockheed Corporation | P-38G-1 Lightning | Block 1";;
 "p-38g_1";"P-38G-1 Lightning";;
 "p-38g_2";"P-38G-1";;
-
+#
 "p-39n_shop";"P-39N-0 Airacobra";;
 "p-39n_0";"Bell Aircraft Corporation | P-39N-0 Airacobra | Block 0";;
 "p-39n_1";"P-39N-0 Airacobra";;
 "p-39n_2";"P-39N-0";;
-
+#
 "p-39q_5_shop";"P-39Q-5 Airacobra";;
 "p-39q_5_0";"Bell Aircraft Corporation | P-39Q-5 Airacobra | Block 5";;
 "p-39q_5_1";"P-39Q-5 Airacobra";;
 "p-39q_5_2";"P-39Q-5";;
-
+#
 "p-36g_shop";"P-36G Hawk";;
 "p-36g_0";"Curtiss-Wright Corporation | P-36G Hawk";;
 "p-36g_1";"P-36G Hawk";;
 "p-36g_2";"P-36G";;
-
+#
 "p-40e_shop";"P-40E-1 Warhawk";;
 "p-40e_0";"Curtiss-Wright Corporation | P-40E-1 Warhawk | Block 1";;
 "p-40e_1";"P-40E-1 Warhawk";;
 "p-40e_2";"P-40E-1";;
-
+#
 "p-40e_td_shop";"P-40E-1 Warhawk [TD]";;
 "p-40e_td_0";"Curtiss-Wright Corporation | P-40E-1 Warhawk | Block 1 [Twitch Drop]";;
 "p-40e_td_1";"P-40E-1 Warhawk [TD]";;
 "p-40e_td_2";"P-40E-1 [TD]";;
-
+#
 "p-40f_10_shop";"P-40F-10 Warhawk";;
 "p-40f_10_0";"Curtiss-Wright Corporation | P-40F-10 Warhawk | Block 10";;
 "p-40f_10_1";"P-40F-10 Warhawk";;
 "p-40f_10_2";"P-40F-10";;
-
+#
 "p-51c-10-nt_shop";"P-51C-10 Mustang";;
 "p-51c-10-nt_0";"North American Aviation | P-51C-10 Mustang | Block 10";;
 "p-51c-10-nt_1";"P-51C-10 Mustang";;
 "p-51c-10-nt_2";"P-51C-10";;
-
+#
 "f2a-3_shop";"F2A-3 Buffalo";;
 "f2a-3_0";"Brewster Aeronautical Corporation | F2A-3 Buffalo";;
 "f2a-3_1";"F2A-3 Buffalo";;
 "f2a-3_2";"F2A-3";;
-
+#
 "f4f-3_shop";"F4F-3 Wildcat";;
 "f4f-3_0";"Grumman Aircraft Engineering Corporation | F4F-3 Wildcat";;
 "f4f-3_1";"F4F-3 Wildcat";;
 "f4f-3_2";"F4F-3";;
-
+#
 "f4f-4_shop";"F4F-4 Wildcat";;
 "f4f-4_0";"Grumman Aircraft Engineering Corporation | F4F-4 Wildcat";;
 "f4f-4_1";"F4F-4 Wildcat";;
 "f4f-4_2";"F4F-4";;
-
+#
 "f6f-3_shop";"F6F-5 Hellcat";;
 "f6f-3_0";"Grumman Aircraft Engineering Corporation | F6F-5 Hellcat";;
 "f6f-3_1";"F6F-5 Hellcat";;
 "f6f-3_2";"F6F-5";;
-
+#
 "f4u-1a_shop";"F4U-1A Corsair";;
 "f4u-1a_0";"Chance Vought Corporation | F4U-1A Corsair";;
 "f4u-1a_1";"F4U-1A Corsair";;
 "f4u-1a_2";"F4U-1A";;
-
+#
 "f4u-1a_usmc_shop";"F4U-1A Corsair (USMC)";;
 "f4u-1a_usmc_0";"Chance Vought Corporation | F4U-1A Corsair (USMC)";;
 "f4u-1a_usmc_1";"F4U-1A Corsair (USMC)";;
 "f4u-1a_usmc_2";"F4U-1A (USMC)";;
-
+#
 "f4u-1d_shop";"F4U-1D Corsair";;
 "f4u-1d_0";"Chance Vought Corporation | F4U-1D Corsair";;
 "f4u-1d_1";"F4U-1D Corsair";;
 "f4u-1d_2";"F4U-1D";;
-
+#
 "p-51_a-36_shop";"A-36 Apache";;
 "p-51_a-36_0";"North American Aviation | A-36 Apache";;
 "p-51_a-36_1";"A-36 Apache";;
 "p-51_a-36_2";"A-36";;
-
+#
 "a-20g_shop";"A-20G-25 Havoc";;
 "a-20g_0";"Douglas Aircraft Company | A-20G-25 Havoc | Block 25";;
 "a-20g_1";"A-20G-25 Havoc";;
 "a-20g_2";"A-20G-25";;
-
+#
 "sb2c_1c_shop";"SB2C-1C Helldiver";;
 "sb2c_1c_0";"Curtiss-Wright Corporation | SB2C-1C Helldiver";;
 "sb2c_1c_1";"SB2C-1 Helldiver";;
 "sb2c_1c_2";"SB2C-1";;
-
+#
 "sb2c_4_shop";"SB2C-4 Helldiver";;
 "sb2c_4_0";"Curtiss-Wright Corporation | SB2C-4 Helldiver";;
 "sb2c_4_1";"SB2C-4 Helldiver";;
 "sb2c_4_2";"SB2C-4";;
-
+#
 "b_34_shop";"B-34 Lexington";;
 "b_34_0";"Lockheed Corporation | B-34 Lexington";;
 "b_34_1";"B-34 Lexington";;
 "b_34_2";"B-34";;
-
+#
 "b_25j_1_shop";"B-25J-1 Mitchell";;
 "b_25j_1_0";"North American Aviation | B-25J-1 Mitchell | Block 1";;
 "b_25j_1_1";"B-25J-1 Mitchell";;
 "b_25j_1_2";"B-25J-1";;
-
+#
 "b_25j_20_shop";"B-25J-20 Mitchell";;
 "b_25j_20_0";"North American Aviation | B-25J-20 Mitchell | Block 20";;
 "b_25j_20_1";"B-25J-20 Mitchell";;
 "b_25j_20_2";"B-25J-20";;
-
+#
 "p-43a-1_shop";"P-43A-1 Lancer";;
 "p-43a-1_0";"Republic Aviation Corporation | P-43A-1 Lancer | Block 1";;
 "p-43a-1_1";"P-43A-1 Lancer";;
 "p-43a-1_2";"P-43A-1";;
-
+#
 "b_26_shop";"B-26 Marauder";;
 "b_26_0";"Martin Company | B-26 Marauder";;
 "b_26_1";"B-26 Marauder";;
 "b_26_2";"B-26";;
-
+#
 "a-26c-45-dt_shop";"A-26C-45 Invader";;
 "a-26c-45-dt_0";"Douglas Aircraft Company | A-26C-45 Invader | Block 45";;
 "a-26c-45-dt_1";"A-26C-45 Invader";;
 "a-26c-45-dt_2";"A-26C-45";;
-
+#
 "a_26c_shop";"A-26C Invader";;
 "a_26c_0";"Douglas Aircraft Company | A-26C Invader";;
 "a_26c_1";"A-26C Invader";;
 "a_26c_2";"A-26C";;
-
+#
 "b_26b_c_shop";"B-26B Marauder";;
 "b_26b_c_0";"Martin Company | B-26B Marauder";;
 "b_26b_c_1";"B-26B Marauder";;
 "b_26b_c_2";"B-26B";;
-
+#
 "p-63a-10_shop";"P-63A-10 Kingcobra";;
 "p-63a-10_0";"Bell Aircraft Corporation | P-63A-10 Kingcobra | Block 10";;
 "p-63a-10_1";"P-63A-10 Kingcobra";;
 "p-63a-10_2";"P-63A-10";;
-
+#
 "p-63a-5_shop";"P-63A-5 Kingcobra";;
 "p-63a-5_0";"Bell Aircraft Corporation | P-63A-5 Kingcobra | Block 5";;
 "p-63a-5_1";"P-63A-5 Kingcobra";;
 "p-63a-5_2";"P-63A-5";;
-
+#
 "p-63c-5_shop";"P-63C-5 Kingcobra";;
 "p-63c-5_0";"Bell Aircraft Corporation | P-63C-5 Kingcobra | Block 5";;
 "p-63c-5_1";"P-63C-5 Kingcobra";;
 "p-63c-5_2";"P-63C-5";;
-
+#
 "p-63c-5_kingcobra_animal_version_shop";"␠P-63C-5 Kingcobra";;
 "p-63c-5_kingcobra_animal_version_0";"␠Bell Aircraft Corporation | P-63C-5 Kingcobra | Block 5";;
 "p-63c-5_kingcobra_animal_version_1";"␠P-63C-5 Kingcobra";;
 "p-63c-5_kingcobra_animal_version_2";"␠P-63C-5";;
-
+#
 "p-38j_shop";"P-38J-15 Lightning";;
 "p-38j_0";"Lockheed Corporation | P-38J-15 Lightning | Block 15";;
 "p-38j_1";"P-38J-15 Lightning";;
 "p-38j_2";"P-38J-15";;
-
+#
 "p-38l_shop";"P-38L-5 Lightning";;
 "p-38l_0";"Lockheed Corporation | P-38L-5 Lightning | Block 5";;
 "p-38l_1";"P-38L-5 Lightning";;
 "p-38l_2";"P-38L-5";;
-
+#
 "p-51d-5_shop";"P-51D-5 Mustang";;
 "p-51d-5_0";"North American Aviation | P-51D-5 Mustang | Block 5";;
 "p-51d-5_1";"P-51D-5 Mustang";;
 "p-51d-5_2";"P-51D-5";;
-
+#
 "p-51_mk1_shop";"P-51 Mustang Mk.1";;
 "p-51_mk1_0";"North American Aviation | P-51 Mustang Mk.1";;
 "p-51_mk1_1";"P-51 Mustang Mk.1";;
 "p-51_mk1_2";"P-51 Mk.1";;
-
+#
 "p-47d_22_re_shop";"P-47D-22 Thunderbolt";;
 "p-47d_22_re_0";"Republic Aviation Corporation | P-47D-22 Thunderbolt | Block 22";;
 "p-47d_22_re_1";"P-47D-22 Thunderbolt";;
 "p-47d_22_re_2";"P-47D-22";;
-
+#
 "p-47d_shop";"P-47D-25 Thunderbolt";;
 "p-47d_0";"Republic Aviation Corporation | P-47D-25 Thunderbolt | Block 25";;
 "p-47d_1";"P-47D-25 Thunderbolt";;
 "p-47d_2";"P-47D-25";;
-
+#
 "f4u-4_shop";"F4U-4 Corsair";;
 "f4u-4_0";"Chance Vought Corporation | F4U-4 Corsair";;
 "f4u-4_1";"F4U-4 Corsair";;
 "f4u-4_2";"F4U-4";;
-
+#
 "f8f1_shop";"F8F-1 Bearcat";;
 "f8f1_0";"Grumman Aircraft Engineering Corporation | F8F-1 Bearcat";;
 "f8f1_1";"F8F-1 Bearcat";;
 "f8f1_2";"F8F-1";;
-
+#
 "f6f-5n_shop";"F6F-5N Hellcat";;
 "f6f-5n_0";"Grumman Aircraft Engineering Corporation | F6F-5N Hellcat";;
 "f6f-5n_1";"F6F-5N Hellcat";;
 "f6f-5n_2";"F6F-5N";;
-
+#
 "pbj_1h_shop";"PBJ-1H Mitchell";;
 "pbj_1h_0";"North American Aviation | PBJ-1H Mitchell";;
 "pbj_1h_1";"PBJ-1H Mitchell";;
 "pbj_1h_2";"PBJ-1H";;
-
+#
 "pbj_1j_shop";"PBJ-1J Mitchell";;
 "pbj_1j_0";"North American Aviation | PBJ-1J Mitchell";;
 "pbj_1j_1";"PBJ-1J Mitchell";;
 "pbj_1j_2";"PBJ-1J";;
-
+#
 "pbj_1j_1_shop";"PBJ-1J-1 Mitchell";;
 "pbj_1j_1_0";"North American Aviation | PBJ-1J-1 Mitchell | Block 1";;
 "pbj_1j_1_1";"PBJ-1J-1 Mitchell";;
 "pbj_1j_1_2";"PBJ-1J-1";;
-
+#
 "p-61c_1_shop";"P-61C-1 Black Widow";;
 "p-61c_1_0";"Northrop Corporation | P-61C-1 Black Widow | Block 1";;
 "p-61c_1_1";"P-61C-1 Black Widow";;
 "p-61c_1_2";"P-61C-1";;
-
+#
 "p-61a_1_shop";"P-61A-11 Black Widow";;
 "p-61a_1_0";"Northrop Corporation | P-61A-11 Black Widow | Block 11";;
 "p-61a_1_1";"P-61A-11 Black Widow";;
 "p-61a_1_2";"P-61A-11 Black Widow";;
-
+#
 "b-17e_shop";"B-17E Flying Fortress (1941)";;
 "b-17e_0";"Boeing Airplane Company | B-17E Flying Fortress | Sperry Ball Turrets (1941)";;
 "b-17e_1";"B-17E Flying Fortress (1941)";;
 "b-17e_2";"B-17E (1941)";;
-
+#
 "b-17e_late_shop";"B-17E Flying Fortress (1942)";;
 "b-17e_late_0";"Boeing Airplane Company | B-17E Flying Fortress | Bendix Ball Turrets (1942)";;
 "b-17e_late_1";"B-17E Flying Fortress (1942)";;
 "b-17e_late_2";"B-17E (1942)";;
-
+#
 "pb4y-2_shop";"PB4Y-2 Privateer";;
 "pb4y-2_0";"Consolidated Aircraft Corporation | PB4Y-2 Privateer";;
 "pb4y-2_1";"PB4Y-2 Privateer";;
 "pb4y-2_2";"PB4Y-2";;
-
+#
 "btd-1_shop";"BTD-1 Destroyer";;
 "btd-1_0";"Douglas Aircraft Company | BTD-1 Destroyer";;
 "btd-1_1";"BTD-1 Destroyer";;
 "btd-1_2";"BTD-1";;
-
+#
 "xf5f_shop";"XF5F Skyrocket";;
 "xf5f_0";"Grumman Aircraft Engineering Corporation | XF5F Skyrocket";;
 "xf5f_1";"XF5F Skyrocket";;
 "xf5f_2";"XF5F";;
-
+#
 "xp-50_shop";"XP-50 Skyrocket";;
 "xp-50_0";"Grumman Aircraft Engineering Corporation | XP-50 Skyrocket";;
 "xp-50_1";"XP-50 Skyrocket";;
 "xp-50_2";"XP-50";;
-
+#
 "xp-55_shop";"XP-55 Ascender";;
 "xp-55_0";"Curtiss-Wright Corporation | XP-55 Ascender";;
 "xp-55_1";"XP-55 Ascender";;
 "xp-55_2";"XP-55";;
-
+#
 "pv_2d_shop";"PV-2D Harpoon";;
 "pv_2d_0";"Lockheed Corporation | PV-2D Harpoon";;
 "pv_2d_1";"PV-2D Harpoon";;
 "pv_2d_2";"PV-2D";;
-
+#
 "pbm_3_shop";"PBM-3 Mariner";;
 "pbm_3_0";"Martin Company | PBM-3 Mariner";;
 "pbm_3_1";"PBM-3 Mariner";;
 "pbm_3_2";"PBM-3";;
-
+#
 "pbm_5a_shop";"PBM-5A Mariner";;
 "pbm_5a_0";"Martin Company | PBM-5A Mariner";;
 "pbm_5a_1";"PBM-5A Mariner";;
 "pbm_5a_2";"PBM-5A";;
-
+#
 "f-82e_shop";"F-82E Twin Mustang";;
 "f-82e_0";"North American Aviation | F-82E Twin Mustang";;
 "f-82e_1";"F-82E Twin Mustang";;
 "f-82e_2";"F-82E";;
-
+#
 "f-82g_0";"North American Aviation | F-82G Twin Mustang";;
 "f-82g_1";"F-82G Twin Mustang";;
 "f-82g_2";"F-82G";;
-
+#
 "p-51d-30_usaaf_korea_shop";"P-51D-30 Mustang";;
 "p-51d-30_usaaf_korea_0";"North American Aviation | P-51D-30 Mustang | Block 30";;
 "p-51d-30_usaaf_korea_1";"P-51D-30 Mustang";;
 "p-51d-30_usaaf_korea_2";"P-51D-30";;
-
+#
 "p-51h-5_na_shop";"P-51H-5 Mustang";;
 "p-51h-5_na_0";"North American Aviation | P-51H-5 Mustang | Block 5";;
 "p-51h-5_na_1";"P-51H-5 Mustang";;
 "p-51h-5_na_2";"P-51H-5";;
-
+#
 "f4u-1c_shop";"F4U-1C Corsair";;
 "f4u-1c_0";"Chance Vought Corporation | F4U-1C Corsair";;
 "f4u-1c_1";"F4U-1C Corsair";;
 "f4u-1c_2";"F4U-1C";;
-
+#
 "f4u-4b_shop";"F4U-4B Corsair";;
 "f4u-4b_0";"Chance Vought Corporation | F4U-4B Corsair";;
 "f4u-4b_1";"F4U-4B Corsair";;
 "f4u-4b_2";"F4U-4B";;
-
+#
 "f4u-4b_vmf_214_shop";"F4U-4B Corsair (VMF-214)";;
 "f4u-4b_vmf_214_0";"Chance Vought Corporation | F4U-4B Corsair (VMF-214)";;
 "f4u-4b_vmf_214_1";"F4U-4B Corsair (VMF-214)";;
 "f4u-4b_vmf_214_2";"F4U-4B (VMF-214)";;
-
+#
 "f8f1b_shop";"F8F-1B Bearcat";;
 "f8f1b_0";"Grumman Aircraft Engineering Corporation | F8F-1B Bearcat";;
 "f8f1b_1";"F8F-1B Bearcat";;
 "f8f1b_2";"F8F-1B";;
-
+#
 "f7f1_shop";"F7F-1 Tigercat";;
 "f7f1_0";"Grumman Aircraft Engineering Corporation | F7F-1 Tigercat";;
 "f7f1_1";"F7F-1 Tigercat";;
 "f7f1_2";"F7F-1";;
-
+#
 "a-26b_shop";"A-26B-50 Invader";;
 "a-26b_0";"Douglas Aircraft Company | A-26B-50 Invader | Block 50";;
 "a-26b_1";"A-26B-50 Invader";;
 "a-26b_2";"A-26B-50";;
-
+#
 "a-26b_10_shop";"A-26B-10 Invader";;
 "a-26b_10_0";"Douglas Aircraft Company | A-26B-10 Invader | Block 10";;
 "a-26b_10_1";"A-26B-10 Invader";;
 "a-26b_10_2";"A-26B-10";;
-
+#
 "spitfire_ix_usa_shop";"▃Spitfire LF.IXc";;
 "spitfire_ix_usa_0";"▃Supermarine Spitfire | Low-Altitude Fighter, Mk.IXc";;
 "spitfire_ix_usa_1";"▃Spitfire LF.IXc";;
 "spitfire_ix_usa_2";"▃Spitfire LF.IXc";;
-
+#
 "douglas_ad_2_shop";"AD-2 Skyraider";;
 "douglas_ad_2_0";"Douglas Aircraft Company | AD-2 Skyraider";;
 "douglas_ad_2_1";"AD-2 Skyraider";;
 "douglas_ad_2_2";"AD-2";;
-
+#
 "douglas_ad_4_shop";"AD-4 Skyraider";;
 "douglas_ad_4_0";"Douglas Aircraft Company | AD-4 Skyraider";;
 "douglas_ad_4_1";"AD-4 Skyraider";;
 "douglas_ad_4_2";"AD-4";;
-
+#
 "am_1_mauler_shop";"AM-1 Mauler";;
 "am_1_mauler_0";"Martin Company | AM-1 Mauler";;
 "am_1_mauler_1";"AM-1 Mauler";;
 "am_1_mauler_2";"AM-1";;
-
+#
 "douglas_a_1h_shop";"A-1H Skyraider";;
 "douglas_a_1h_0";"Douglas Aircraft Company | A-1H Skyraider";;
 "douglas_a_1h_1";"A-1H Skyraider";;
 "douglas_a_1h_2";"A-1H";;
-
+#
 "b-17g_shop";"B-17G-60 Flying Fortress";;
 "b-17g_0";"Boeing Airplane Company | B-17G-60 Flying Fortress | Block 60";;
 "b-17g_1";"B-17G-60 Flying Fortress";;
 "b-17g_2";"B-17G-60";;
-
+#
 "b_24d_shop";"B-24D-25 Liberator";;
 "b_24d_0";"Consolidated Aircraft Corporation | B-24D-25 Liberator | Block 25";;
 "b_24d_1";"B-24D-25 Liberator";;
 "b_24d_2";"B-24D-25";;
-
+#
 "b-29_shop";"B-29A Superfortress";;
 "b-29_0";"Boeing Airplane Company | B-29A Superfortress";;
 "b-29_1";"B-29A Superfortress";;
 "b-29_2";"B-29A";;
-
+#
 "p-51d-20-na_shop";"P-51D-20 Mustang";;
 "p-51d-20-na_0";"North American Aviation | P-51D-20 Mustang | Block 20";;
 "p-51d-20-na_1";"P-51D-20 Mustang";;
 "p-51d-20-na_2";"P-51D-20";;
-
+#
 "xa_38_shop";"XA-38 Grizzly";;
 "xa_38_0";"Beechcraft Aircraft Corp. XA-38 Grizzly";;
 "xa_38_1";"XA-38 Grizzly";;
 "xa_38_2";"XA-38";;
-
+#
 "p-38j_marge_shop";"P-38J-15 Lightning [Bong]";;
 "p-38j_marge_0";"Lockheed Corporation | Richard Bong's P-38J-15 Lightning | Block 15";;
 "p-38j_marge_1";"P-38J-15 Lightning [Bong]";;
 "p-38j_marge_2";"P-38J-15";;
-
+#
 "p-59a_shop";"P-59A Airacomet";;
 "p-59a_0";"Bell Aircraft Corporation | P-59A Airacomet";;
 "p-59a_1";"P-59A Airacomet";;
 "p-59a_2";"P-59A";;
-
+#
 "f4u-6_au-1_shop";"AU-1 Corsair";;
 "f4u-6_au-1_0";"Chance Vought Corporation | AU-1 Corsair";;
 "f4u-6_au-1_1";"AU-1 Corsair";;
 "f4u-6_au-1_2";"AU-1";;
-
+#
 "f2g-1_shop";"F2G-1 Super Corsair";;
 "f2g-1_0";"Goodyear Aircraft Company | F2G-1 Super Corsair";;
 "f2g-1_1";"F2G-1 Super Corsair";;
 "f2g-1_2";"F2G-1";;
-
+#
 "f7f3_shop";"F7F-3 Tigercat";;
 "f7f3_0";"Grumman Aircraft Engineering Corporation | F7F-3 Tigercat";;
 "f7f3_1";"F7F-3 Tigercat";;
 "f7f3_2";"F7F-3";;
-
+#
 "f-80a_shop";"F-80A-5 Shooting Star";;
 "f-80a_0";"Lockheed Corporation | F-80A-5 Shooting Star | Block 5";;
 "f-80a_1";"F-80A-5 Shooting Star";;
 "f-80a_2";"F-80A-5";;
-
+#
 "f-80_shop";"F-80C-10 Shooting Star";;
 "f-80_0";"Lockheed Corporation | F-80C-10 Shooting Star | Block 10";;
 "f-80_1";"F-80C-10 Shooting Star";;
 "f-80_2";"F-80C-10";;
-
+#
 "f-84b_shop";"F-84B-26 Thunderjet";;
 "f-84b_0";"Republic Aviation Corporation | F-84B-26 Thunderjet | Block 26";;
 "f-84b_1";"F-84B-26 Thunderjet";;
 "f-84b_2";"F-84B-26";;
-
+#
 "f-84g_shop";"F-84G-21 Thunderjet";;
 "f-84g_0";"Republic Aviation Corporation | F-84G-21 Thunderjet | Block 21";;
 "f-84g_1";"F-84G-21 Thunderjet";;
 "f-84g_2";"F-84G-21";;
-
+#
 "f-86a-5_shop";"F-86A-5 Sabre";;
 "f-86a-5_0";"North American Aviation | F-86A-5 Sabre | Block 5";;
 "f-86a-5_1";"F-86A-5 Sabre";;
 "f-86a-5_2";"F-86A-5";;
-
+#
 "f-86f-25_shop";"F-86F-25 Sabre";;
 "f-86f-25_0";"North American Aviation | F-86F-25 Sabre | Block 25";;
 "f-86f-25_1";"F-86F-25 Sabre";;
 "f-86f-25_2";"F-86F-25";;
-
+#
 "f2h-2_shop";"F2H-2 Banshee";;
 "f2h-2_0";"McDonnell F2H-2 Banshee";;
 "f2h-2_1";"F2H-2 Banshee";;
 "f2h-2_2";"F2H-2";;
-
+#
 "f9f-2_shop";"F9F-2 Panther";;
 "f9f-2_0";"Grumman Aircraft Engineering Corporation | F9F-2 Panther";;
 "f9f-2_1";"F9F-2 Panther";;
 "f9f-2_2";"F9F-2";;
-
+#
 "f9f-5_shop";"F9F-5 Panther";;
 "f9f-5_0";"Grumman Aircraft Engineering Corporation | F9F-5 Panther";;
 "f9f-5_1";"F9F-5 Panther";;
 "f9f-5_2";"F9F-5";;
-
+#
 "f9f-8_shop";"F9F-8 Cougar";;
 "f9f-8_0";"Grumman Aircraft Engineering Corporation | F9F-8 Cougar";;
 "f9f-8_1";"F9F-8 Cougar";;
 "f9f-8_2";"F9F-8";;
-
+#
 "f3d_1_shop";"F3D-1 Skyknight";;
 "f3d_1_0";"Douglas Aircraft Company | F3D-1 Skyknight";;
 "f3d_1_1";"F3D-1 Skyknight";;
 "f3d_1_2";"F3D-1";;
-
+#
 "f-84f_shop";"F-84F Thunderstreak";;
 "f-84f_0";"Republic Aviation Corporation | F-84F Thunderstreak";;
 "f-84f_1";"F-84F Thunderstreak";;
 "f-84f_2";"F-84F";;
-
+#
 "b-57_shop";"▃B-57A Canberra";;
 "b-57_0";"▃Martin Company | B-57A Canberra";;
 "b-57_1";"▃B-57A Canberra";;
 "b-57_2";"▃B-57A";;
-
+#
 "b-57b_shop";"▃B-57B Canberra";;
 "b-57b_0";"▃Martin Company | B-57B Canberra";;
 "b-57b_1";"▃B-57B Canberra";;
 "b-57b_2";"▃B-57B";;
-
+#
 "f-89d_shop";"F-89D Scorpion";;
 "f-89d_0";"Northrop Corporation | F-89D Scorpion";;
 "f-89d_1";"F-89D Scorpion";;
 "f-89d_2";"F-89D";;
-
+#
 "f-89b_shop";"F-89B Scorpion";;
 "f-89b_0";"Northrop Corporation | F-89B Scorpion";;
 "f-89b_1";"F-89B Scorpion";;
 "f-89b_2";"F-89B";;
-
+#
 "a2d_shop";"A2D-1 Skyshark";;
 "a2d_0";"Douglas Aircraft Company | A2D-1 Skyshark";;
 "a2d_1";"A2D-1 Skyshark";;
 "a2d_2";"A2D-1";;
-
+#
 "f-104a_shop";"F-104A Starfighter";;
 "f-104a_0";"Lockheed Corporation | F-104A Starfighter";;
 "f-104a_1";"F-104A Starfighter";;
 "f-104a_2";"F-104A";;
-
+#
 "f-104c_shop";"F-104C Starfighter";;
 "f-104c_0";"Lockheed Corporation | F-104C Starfighter";;
 "f-104c_1";"F-104C Starfighter";;
 "f-104c_2";"F-104C";;
-
+#
 "f-86f-2_shop";"F-86F-2 Sabre";;
 "f-86f-2_0";"North American Aviation | F-86F-2 Sabre | Block 2";;
 "f-86f-2_1";"F-86F-2 Sabre";;
 "f-86f-2_2";"F-86F-2";;
-
+#
 "f-100d_shop";"F-100D Super Sabre";;
 "f-100d_0";"North American Aviation | F-100D Super Sabre";;
 "f-100d_1";"F-100D Super Sabre";;
 "f-100d_2";"F-100D";;
-
+#
 "f3h-2_shop";"F3H-2 Demon";;
 "f3h-2_0";"McDonnell Douglas Corporation | F3H-2 Demon";;
 "f3h-2_1";"F3H-2 Demon";;
 "f3h-2_2";"F3H-2";;
-
+#
 "f8u-2_shop";"F8U-2 Crusader II";;
 "f8u-2_0";"Chance Vought Corporation | F8U-2 Crusader II";;
 "f8u-2_1";"F8U-2 Crusader II";;
 "f8u-2_2";"F8U-2";;
-
+#
 "a_4b_shop";"A-4B Skyhawk";;
 "a_4b_0";"Douglas Aircraft Company | A-4B Skyhawk";;
 "a_4b_1";"A-4B Skyhawk";;
 "a_4b_2";"A-4B";;
-
+#
 "a_4e_early_shop";"A-4E Skyhawk (1956)";;
 "a_4e_early_0";"Douglas Aircraft Company | A-4E Skyhawk (1956)";;
 "a_4e_early_1";"A-4E Skyhawk (1956)";;
 "a_4e_early_2";"A-4E (1956)";;
-
+#
 "fj_4b_shop";"FJ-4B Fury";;
 "fj_4b_0";"North American Aviation | FJ-4B Fury";;
 "fj_4b_1";"FJ-4B Fury";;
 "fj_4b_2";"FJ-4B";;
-
+#
 "fj_4b_agm_12b_shop";"FJ-4B Fury (VMF-232)";;
 "fj_4b_agm_12b_0";"North American Aviation | FJ-4B Fury (VMF-232)";;
 "fj_4b_agm_12b_1";"FJ-4B Fury (VMF-232)";;
 "fj_4b_agm_12b_2";"FJ-4B (VMF-232)";;
-
+#
 "av_8a_shop";"▃AV-8A Harrier";;
 "av_8a_0";"Hawker Siddeley Group, Ltd. | ▃AV-8A Harrier";;
 "av_8a_1";"▃AV-8A Harrier";;
 "av_8a_2";"▃AV-8A";;
-
+#
 "av_8c_shop";"▃AV-8C Harrier";;
 "av_8c_0";"Hawker Siddeley Group, Ltd. | ▃AV-8C Harrier";;
 "av_8c_1";"▃AV-8C Harrier";;
-"av_8c_2";"▃AV-8C";"AV-8";;
-
+"av_8c_2";"▃AV-8C";;
+#
 "f_117_shop";"F-117A Nighthawk";;
 "f_117_0";"Lockheed Corporation | F-117A Nighthawk";;
 "f_117_1";"F-117A Nighthawk";;
 "f_117_2";"F-117A";;
-
+#
 "a_10a_early_shop";"A-10A Warthog (1976)";;
 "a_10a_early_0";"Fairchild Republic | A-10A Warthog (1976)";;
 "a_10a_early_1";"A-10A Warthog (1976)";;
 "a_10a_early_2";"A-10A (1976)";;
-
+#
 "f11f_1_late_shop";"F11F-1 Tiger";;
 "f11f_1_late_0";"Grumman Aircraft Engineering Corporation | F11F-1 Tiger";;
 "f11f_1_late_1";"F11F-1 Tiger";;
 "f11f_1_late_2";"F11F-1";;
-
+#
 "f4d_1_shop";"F4D-1 Skyray";;
 "f4d_1_0";"Douglas Aircraft Company | F4D-1 Skyray";;
 "f4d_1_1";"F4D-1 Skyray";;
 "f4d_1_2";"F4D-1";;
-
+#
 "f-5c_shop";"F-5C Skoshi Tiger";;
 "f-5c_0";"Northrop Corporation | F-5C Skoshi Tiger";;
 "f-5c_1";"F-5C Skoshi Tiger";;
 "f-5c_2";"F-5C";;
-
+#
 "f-5e_shop";"F-5E Tiger II";;
 "f-5e_0";" Northrop Corporation | F-5E Tiger II";;
 "f-5e_1";"F-5E Tiger II";;
 "f-5e_2";"F-5E";;
-
+#
 "f-4c_shop";"F-4C Phantom II";;
 "f-4c_0";"McDonnell Douglas Corporation | F-4C Phantom II";;
 "f-4c_1";"F-4C Phantom II";;
 "f-4c_2";"F-4C";;
-
+#
 "f-4e_shop";"F-4E Phantom II";;
 "f-4e_0";"McDonnell Douglas Corporation | F-4E Phantom II";;
 "f-4e_1";"F-4E Phantom II";;
 "f-4e_2";"F-4E";;
-
+#
 "f-8e_shop";"F-8E Crusader";;
 "f-8e_0";"Chance Vought Corporation | F-8E Crusader";;
 "f-8e_1";"F-8E Crusader";;
 "f-8e_2";"F-8E";;
-
+#
 "f-4j_shop";"F-4J Phantom II";;
 "f-4j_0";"McDonnell Douglas Corporation | F-4J Phantom II";;
 "f-4j_1";"F-4J Phantom II";;
 "f-4j_2";"F-4J";;
-
+#
 "f-4s_shop";"F-4S Phantom II";;
 "f-4s_0";"McDonnell Douglas Corporation | F-4S Phantom II";;
 "f-4s_1";"F-4S Phantom II";;
 "f-4s_2";"F-4S";;
-
+#
 "a_10a_late_shop";"A-10A Warthog (1978)";;
 "a_10a_late_0";"Fairchild Republic | A-10A Warthog (1978)";;
 "a_10a_late_1";"A-10A Warthog (1978)";;
 "a_10a_late_2";"A-10A (1978)";;
-
+#
 "a_10c_shop";"A-10C Warthog";;
 "a_10c_0";"Northrop Grumman Corporation | A-10C Warthog";;
 "a_10c_1";"A-10C Warthog";;
 "a_10c_2";"A-10C";;
-
+#
 "a_7d_shop";"A-7D Corsair II";;
 "a_7d_0";"LTV Aerospace Corporation | A-7D Corsair II";;
 "a_7d_1";"A-7D Corsair II";;
 "a_7d_2";"A-7D";;
-
+#
 "a_7e_shop";"A-7E Corsair II";;
 "a_7e_0";"LTV Aerospace Corporation | A-7E Corsair II";;
 "a_7e_1";"A-7E Corsair II";;
 "a_7e_2";"A-7E";;
-
+#
 "f-105d_shop";"F-105D Thunderchief";;
 "f-105d_0";"Republic Aviation Corporation | F-105D Thunderchief";;
 "f-105d_1";"F-105D Thunderchief";;
 "f-105d_2";"F-105D";;
-
+#
 "f_111a_shop";"F-111A Aardvark";;
 "f_111a_0";"General Dynamics Corporation | F-111A Aardvark";;
 "f_111a_1";"F-111A Aardvark";;
 "f_111a_2";"F-111A";;
-
+#
 "f_111f_shop";"F-111F Aardvark";;
 "f_111f_0";"General Dynamics Corporation | F-111F Aardvark";;
 "f_111f_1";"F-111F Aardvark";;
 "f_111f_2";"F-111F";;
-
+#
+f_111f_killstreak_shop;☢F-111F Aardvark;;
+f_111f_killstreak_0;General Dynamics Corporation | ☢F-111F Aardvark;;
+f_111f_killstreak_1;☢F-111F Aardvark;;
+f_111f_killstreak_2;☢F-111F;;
+#
 "f-5a_shop";"F-5A Freedom Fighter";;
 "f-5a_0";"Northrop Corporation | F-5A Freedom Fighter";;
 "f-5a_1";"F-5A Freedom Fighter";;
 "f-5a_2";"F-5A";;
-
+#
 "a_7k_shop";"A-7K Corsair II";;
 "a_7k_0";"LTV Aerospace Corporation | A-7K Corsair II";;
 "a_7k_1";"A-7K Corsair II";;
 "a_7k_2";"A-7K";;
-
+#
 "a_6e_tram_shop";"A-6E TRAM Intruder";;
 "a_6e_tram_0";"Grumman Aerospace Corporation | A-6E TRAM Intruder";;
 "a_6e_tram_1";"A-6E TRAM Intruder";;
 "a_6e_tram_2";"A-6E TRAM";;
-
+#
 "av_8b_na_shop";"AV-8B Night Attack Harrier II";;
 "av_8b_na_0";"McDonnell Douglas Corporation | AV-8B Night Attack Harrier II";;
 "av_8b_na_1";"AV-8B Night Attack Harrier II";;
 "av_8b_na_2";"AV-8B (NA)";;
-
+#
 "f_15c_msip2_shop";"F-15C-40 MSIP II Eagle";;
 "f_15c_msip2_0";"Boeing Defense, Space & Security | F-15C-40 Eagle | Block 40 | Multi-Stage Improvement Program Configuration II (2000)";;
 "f_15c_msip2_1";"F-15C-40 MSIP II Eagle";;
 "f_15c_msip2_2";"F-15C-40";;
-
+#
 "f_15e_shop";"F-15E-43 Strike Eagle";;
 "f_15e_0";"McDonnell Douglas Corporation | F-15E-43 Strike Eagle | Block 43";;
 "f_15e_1";"F-15E-43 Strike Eagle";;
 "f_15e_2";"F-15E-43";;
-
+#
 "fa_18a_shop";"F/A-18A-18 Hornet";;
 "fa_18a_0";"McDonnell Douglas Corporation | F/A-18A-18 Hornet | Block 18, Lot 8";;
 "fa_18a_1";"F/A-18A-18 Hornet";;
 "fa_18a_2";"F/A-18A-18";;
-
+#
 "fa_18c_early_shop";"F/A-18C-23 Hornet";;
 "fa_18c_early_0";"McDonnell Douglas Corporation | F/A-18C-23 Hornet | Block 23, Lot 10 (1987)";;
 "fa_18c_early_1";"F/A-18C-23 Hornet";;
 "fa_18c_early_2";"F/A-18C-23";;
-
+#
 "fa_18c_late_shop";"F/A-18C-52 Hornet";;
 "fa_18c_late_0";"The Boeing Company | F/A-18C-52 Hornet | Block 52, Lot 20 (1992)";;
 "fa_18c_late_1";"F/A-18C-52 Hornet";;
 "fa_18c_late_2";"F/A-18C-52";;
-
+#
 "f_16a_block_10_shop";"F-16A-15OCU Viper";;
 "f_16a_block_10_0";"General Dynamics Corporation | F-16A-15 Viper | Block 15 | Operational Capability Upgrade";;
 "f_16a_block_10_1";"F-16A-15OCU Viper";;
 "f_16a_block_10_2";"F-16A-15OCU";;
-
+#
 "f_16a_block_15_adf_shop";"F-16A-15ADF Viper";;
 "f_16a_block_15_adf_0";"General Dynamics Corporation | F-16A-15 Viper | Block 15 | Air Defense Fighter";;
 "f_16a_block_15_adf_1";"F-16A-15ADF Viper";;
 "f_16a_block_15_adf_2";"F-16A-15ADF";;
-
+#
 "f_16c_block_50_shop";"F-16C-50 Viper";;
 "f_16c_block_50_0";"General Dynamics Corporation | F-16C-50 Viper | Block 50";;
 "f_16c_block_50_1";"F-16C-50 Viper";;
 "f_16c_block_50_2";"F-16C-50";;
-
+#
 "f_16c_block_50_missile_test_shop";"F-16C-50 Viper";;
 "f_16c_block_50_missile_test_0";"General Dynamics Corporation | F-16C-50 Viper | Block 50";;
 "f_16c_block_50_missile_test_1";"F-16C-50 Viper";;
 "f_16c_block_50_missile_test_2";"F-16C-50";;
-
+#
 "f_14a_early_shop";"F-14A-110 Tomcat";;
 "f_14a_early_0";"Grumman Aerospace Corporation | F-14A-110 Tomcat | Block 110 (1980)";;
 "f_14a_early_1";"F-14A-110 Tomcat";;
 "f_14a_early_2";"F-14A-110";;
-
+#
 "f_14a_iriaf_shop";"☫F-14A-90/1995 Tomcat";;
 "f_14a_iriaf_0";"☫Grumman Aerospace Corporation | F-14A-90 Tomcat | Block 90, Mod. 1995";;
 "f_14a_iriaf_1";"☫F-14A-90/1995 Tomcat";;
 "f_14a_iriaf_2";"☫F-14A-90/1995";;
-
+#
 "f_14b_shop";"F-14B-150 Tomcat";;
 "f_14b_0";"Grumman Aerospace Corporation | F-14B-150 Tomcat | Block 150 | Operational Flight Program 321 (2001)";;
 "f_14b_1";"F-14B-150 Tomcat";;
 "f_14b_2";"F-14B-150";;
-
+#
 "f_15a_shop";"F-15A-20 MSIP I Eagle";;
 "f_15a_0";"McDonnell Douglas Corporation | F-15A-20 Eagle | Block 20 | Multi-Stage Improvement Program Configuration I (1983)";;
 "f_15a_1";"F-15A-20 MSIP I Eagle";;
 "f_15a_2";"F-15A-20 MSIP I";;
-
+#
 "av_8b_plus_shop";"AV-8B+ Harrier II";;
 "av_8b_plus_0";"McDonnell Douglas Corporation | AV-8B+ Harrier II";;
 "av_8b_plus_1";"AV-8B+ Harrier II";;
 "av_8b_plus_2";"AV-8B+";;
-
+#
 "f_20a_shop";"F-20A Tigershark";;
 "f_20a_0";"Northrop Corporation | F-20A Tigershark";;
 "f_20a_1";"F-20A Tigershark";;
 "f_20a_2";"F-20A";;
-
+#
 "f-86f-35_shop";"F-86F-35 Sabre";;
 "f-86f-35_0";"North American Aviation | F-86F-35 Sabre | Block 35";;
 "f-86f-35_1";"F-86F-35 Sabre";;
 "f-86f-35_2";"F-86F-35";;
-
+#
 "p-38k_shop";"P-38K Lightning";;
 "p-38k_0";"Lockheed Corporation | P-38K Lightning";;
 "p-38k_1";"P-38K Lightning";;
 "p-38k_2";"P-38K";;
-
+#
 "p-51_mk1a_usaaf_shop";"P-51 Mustang Mk.1A";;
 "p-51_mk1a_usaaf_0";"North American Aviation | P-51 Mustang Mk.1A";;
 "p-51_mk1a_usaaf_1";"P-51 Mustang Mk.1A";;
 "p-51_mk1a_usaaf_2";"P-51 Mk.1A";;
-
+#
 "p-47n-15_shop";"P-47N-15 Thunderbolt";;
 "p-47n-15_0";"Republic Aviation Corporation | P-47N-15 Thunderbolt | Block 15";;
 "p-47n-15_1";"P-47N-15 Thunderbolt";;
 "p-47n-15_2";"P-47N-15";;
-
+#
 "p-47d-28_shop";"P-47D-28 Thunderbolt";;
 "p-47d-28_0";"Republic Aviation Corporation | P-47D-28 Thunderbolt | Block 28";;
 "p-47d-28_1";"P-47D-28 Thunderbolt";;
 "p-47d-28_2";"P-47D-28";;
-
+#
 "p-40c_shop";"P-40C Warhawk";;
 "p-40c_0";"Curtiss-Wright Corporation | P-40C Warhawk";;
 "p-40c_1";"P-40C Warhawk";;
 "p-40c_2";"P-40C";;
-
+#
 "f_106a_1972_shop";"F-106A-100 Delta Dart (1975)";;
 "f_106a_1972_0";"General Dynamics Convair Division | F-106A-100 Delta Dart | Block 100 | Project Six Shooter | Polhemus Director FCS Integration and Test (1975)";;
 "f_106a_1972_1";"F-106A-100 Delta Dart (1975)";;
 "f_106a_1972_2";"F-106A-100 (1975)";;
-
+#
 "f_15c_golden_eagle_shop";"F-15C-33 RIP/PASS Golden Eagle";;
 "f_15c_golden_eagle_0";"Boeing Defense, Space & Security | F-15C-33 Golden Eagle | Radar Improvement Program | Passive Attack Sensor System";;
 "f_15c_golden_eagle_1";"F-15C-33 RIP/PASS Golden Eagle";;
 "f_15c_golden_eagle_2";"F-15C-33 RIP/PASS";;
-
+#
 "xf5u_1_shop";"XF5U-1 Flying Flapjack";;
 "xf5u_1_0";"Vought-Sikorsky Aircraft | XF5U-1 Flying Flapjack";;
 "xf5u_1_1";"XF5U-1 Flying Flapjack";;
 "xf5u_1_2";"XF5U-1";;
-
+#
+"b_66b_shop";"B-66B Destroyer";;
+"b_66b_0";"Douglas Aircraft Company | B-66B Destroyer";;
+"b_66b_1";"B-66B Destroyer";;
+"b_66b_2";"B-66B";;
+#
 "shop/group/p-26_group";"P-26 Peashooter";;
 "shop/group/p-36_group";"P-36 Hawk";;
 "shop/group/f2a_group";"F2A Buffalo";;
@@ -965,10 +975,10 @@ noverify>";"<English>";
 "shop/group/f4f_group";"F4F/F6F";;
 "shop/group/f6f_group";"F6F Bearcat";;
 "shop/group/f4u-1a_group";"F4U-1A Corsair";;
-"shop/group/sb2c_group";"SB2C Helldiver";
+"shop/group/sb2c_group";"SB2C Helldiver";;
 "shop/group/a-26b_group";"A-26B Invader";;
 "shop/group/p-63_group";"P-63 Kingcobra";;
-"shop/group/p-47_group";"P-47D Thunderbolt";
+"shop/group/p-47_group";"P-47D Thunderbolt";;
 "shop/group/pbj_group";"PBJ-1 Mitchell";;
 "shop/group/f8f1_group";"F8F/F7F";;
 "shop/group/f_14_group";"F-14 Tomcat";;
@@ -977,3 +987,14 @@ noverify>";"<English>";
 "shop/group/f_86_group";"F-86 Sabre";;
 "shop/group/p-39_group";"P-39 Airacobra";;
 "shop/group/f4u_group";"F4U Corsair";;
+#
+#helicopters
+"ah_64e_shop";"AH-64E Guardian Apache (v6)";;
+"ah_64e_0";"Boeing Defense, Space & Security | Helicopter, Attack, AH-64E Guardian Apache | Capability Version 6";;
+"ah_64e_1";"AH-64E Guardian Apache (v6)";;
+"ah_64e_2";"AH-64E (v6)";;
+#
+"ah_56a_shop";"AH-56A Cheyenne";;
+"ah_56a_0";"Lockheed Corporation | Helicopter, Attack, AH-56A Cheyenne";;
+"ah_56a_1";"AH-56A Cheyenne";;
+"ah_56a_2";"AH-56A";;

--- a/Mod Files/syrup_weapons.csv
+++ b/Mod Files/syrup_weapons.csv
@@ -1,5 +1,4 @@
-"<ID|readonly|
-noverify>";"<English>";
+"<ID|readonly|noverify>";"<English>";
 
 //Unit Measurements
 "mass/kg";"%dkg";;
@@ -966,16 +965,16 @@ noverify>";"<English>";
 "weapons/us_agm_123/short";"AGM-123 Skipper (1000lb.)";;
 
 "weapons/us_agm_119a_penguin";"AGM-119A Penguin Infrared-Guided Anti-Ship Missiles";;
-"weapons/us_agm_119a_penguin/short";"AGM-119A Penguin ASM";;
+"weapons/us_agm_119a_penguin/short";"AGM-119A Penguin";;
 
 "weapons/us_agm_12b_bullpup";"AGM-12B Bullpup Air-to-Ground Missiles";;
-"weapons/us_agm_12b_bullpup/short";"AGM-12B Bullpup AGM";;
+"weapons/us_agm_12b_bullpup/short";"AGM-12B Bullpup";;
 
 "weapons/us_agm_12b_bullpup_heli";"AGM-12B Bullpup Air-to-Ground Missiles";;
-"weapons/us_agm_12b_bullpup_heli/short";"AGM-12B Bullpup AGM";;
+"weapons/us_agm_12b_bullpup_heli/short";"AGM-12B Bullpup";;
 
 "weapons/us_agm_12c_bullpup";"AGM-12C Bullpup Air-to-Ground Missiles";;
-"weapons/us_agm_12c_bullpup/short";"AGM-12C Bullpup AGM";;
+"weapons/us_agm_12c_bullpup/short";"AGM-12C Bullpup";;
 
 "weapons/us_2000lb_agm_130a";"AGM-130A Infrared-Guided Air-to-Ground Missile (2000lb.)";;
 "weapons/us_2000lb_agm_130a/short";"AGM-130A (2000lb.)";;
@@ -1278,13 +1277,13 @@ noverify>";"<English>";
 "weapons/it_aspide_1a/short";"Aspide-1A";;
 
 //Missiles, FR
-"weapons/fr_r_550_magic";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk 1 Air-to-Air Missiles";;
+"weapons/fr_r_550_magic";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk1 Air-to-Air Missiles";;
 "weapons/fr_r_550_magic/short";"R550 MAGIC I";;
 
-"weapons/fr_r_550_magic_2";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk 2 Air-to-Air Missiles";;
+"weapons/fr_r_550_magic_2";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk2 Air-to-Air Missiles";;
 "weapons/fr_r_550_magic_2/short";"R550 MAGIC II";;
 
-"weapons/fr_r_550_magic_2_default";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk 2 Air-to-Air Missiles";;
+"weapons/fr_r_550_magic_2_default";"Missile Auto-Guidé Interception et Combat (MAGIC) R550 Mk2 Air-to-Air Missiles";;
 "weapons/fr_r_550_magic_2_default/short";"R550 MAGIC II";;
 
 "weapons/fr_r_530_matra_ir";"R.530E Air-to-Air Missiles";;
@@ -1296,10 +1295,10 @@ noverify>";"<English>";
 "weapons/fr_r_511_matra";"R.511 Air-to-Air Missiles";;
 "weapons/fr_r_511_matra/short";"R.511";;
 
-"weapons/fr_mica_em";"Missile d'Interception, de Combat et d'Auto-défense (MICA) Électromagnétique Air-to-Air Missiles";;
+"weapons/fr_mica_em";"Missile d'Interception, de Combat et d'Auto-défense Électromagnétique (MICA-EM) Air-to-Air Missiles";;
 "weapons/fr_mica_em/short";"MICA-EM";;
 
-"weapons/fr_mica_em_default";"Missile d'Interception, de Combat et d'Auto-défense (MICA) Électromagnétique Air-to-Air Missiles";;
+"weapons/fr_mica_em_default";"Missile d'Interception, de Combat et d'Auto-défense Électromagnétique (MICA-EM) Air-to-Air Missiles";;
 "weapons/fr_mica_em_default/short";"MICA-EM";;
 
 //Missiles, SWE
@@ -1359,43 +1358,43 @@ noverify>";"<English>";
 
 //Bombs, USA
 "weapons/us_gbu_12_paveway_2";"GBU-12 Paveway II Laser-Guided Bomb (500lb.)";;
-"weapons/us_gbu_12_paveway_2/short";"GBU-12 Paveway II LGB (500lb.)";;
+"weapons/us_gbu_12_paveway_2/short";"GBU-12 Paveway II (500lb.)";;
 
 "weapons/us_gbu_49_paveway_2";"EGBU-12 Enhanced Paveway II Dual-Mode Laser-Guided Bomb (500lb.)";;
-"weapons/us_gbu_49_paveway_2/short";"EGBU-12 Paveway II DMLGB (500lb.)";;
+"weapons/us_gbu_49_paveway_2/short";"EGBU-12 Paveway II (500lb.)";;
 
 "weapons/us_gbu_48_paveway_2";"EGBU-16 Enhanced Paveway II Dual-Mode Laser-Guided Bombs (1000lb.)";;
-"weapons/us_gbu_48_paveway_2/short";"EGBU-16 Paveway II DMLGB (1000lb.)";;
+"weapons/us_gbu_48_paveway_2/short";"EGBU-16 Paveway II (1000lb.)";;
 
 "weapons/us_gbu_50_paveway_2";"EGBU-10 Enhanced Paveway II Dual-Mode Laser-Guided Bombs (2000lb.)";;
-"weapons/us_gbu_50_paveway_2/short";"EGBU-10 Paveway II DMLGB (2000lb.)";;
+"weapons/us_gbu_50_paveway_2/short";"EGBU-10 Paveway II (2000lb.)";;
 
 "weapons/us_gbu_16_paveway_2";"GBU-16 Paveway II Laser-Guided Bombs (1000lb.)";;
 "weapons/us_gbu_16_paveway_2/short";"GBU-16 Paveway II (1000lb.)";;
 
 "weapons/us_gbu_10_paveway_2";"GBU-10 Paveway II Laser-Guided Bombs (2000lb.)";;
-"weapons/us_gbu_10_paveway_2/short";"GBU-10 Paveway II LGB (2000lb.)";;
+"weapons/us_gbu_10_paveway_2/short";"GBU-10 Paveway II (2000lb.)";;
 
 "weapons/us_2000lb_gbu_24";"GBU-24 Paveway III Laser-Guided Bombs (2000lb.)";;
-"weapons/us_2000lb_gbu_24/short";"GBU-24 Paveway III LGB (2000lb.)";;
+"weapons/us_2000lb_gbu_24/short";"GBU-24 Paveway III (2000lb.)";;
 
 "weapons/us_2000lb_gbu_27";"GBU-27 Paveway III Laser-Guided Bombs (2000lb.)";;
-"weapons/us_2000lb_gbu_27/short";"GBU-27 Paveway III LGB (2000lb.)";;
+"weapons/us_2000lb_gbu_27/short";"GBU-27 Paveway III (2000lb.)";;
 
 "weapons/us_gbu_22_paveway_3";"GBU-22 Paveway III Laser-Guided Bombs (500lb.)";;
-"weapons/us_gbu_22_paveway_3/short";"GBU-22 Paveway III LGB (500lb.)";;
+"weapons/us_gbu_22_paveway_3/short";"GBU-22 Paveway III (500lb.)";;
 
 "weapons/us_gbu_39";"GBU-39/B SDB I GPS-Guided Glide Bombs (250lb.)";;
 "weapons/us_gbu_39/short";"GBU-39/B SDB I (250lb)";;
 
 "weapons/us_2000lb_egbu_24_paveway_3";"EGBU-24B Enhanced Paveway III Dual-Mode Laser-Guided Bombs (2000lb.)";;
-"weapons/us_2000lb_egbu_24_paveway_3/short";"EGBU-24B Paveway III DMLGB (2000lb.)";;
+"weapons/us_2000lb_egbu_24_paveway_3/short";"EGBU-24B Paveway III (2000lb.)";;
 
 "weapons/us_2000lb_gbu_15v1";"GBU-15(V)1/B Television-Guided Bombs (2000lb.)";;
-"weapons/us_2000lb_gbu_15v1/short";"GBU-15(V)1/B TGB (2000lb.)";;
+"weapons/us_2000lb_gbu_15v1/short";"GBU-15(V)1/B (2000lb.)";;
 
 "weapons/us_2000lb_gbu_15v2";"GBU-15(V)2/B Infrared-Guided Bombs (2000lb.)";;
-"weapons/us_2000lb_gbu_15v2/short";"GBU-15(V)2/B IRGB (2000lb.)";;
+"weapons/us_2000lb_gbu_15v2/short";"GBU-15(V)2/B (2000lb.)";;
 
 "weapons/us_2000lb_gbu_8_hobos";"GBU-8 Television-Guided Homing Bomb System (2000lb.)";;
 "weapons/us_2000lb_gbu_8_hobos/short";"GBU-8 HOBOS (2000lb.)";;
@@ -1433,14 +1432,14 @@ noverify>";"<English>";
 "weapons/us_agm_62a_2_erdl";"AGM-62A Walleye II Extended-Range Datalink Television-Guided Bombs (825lb.)";;
 "weapons/us_agm_62a_2_erdl/short";"AGM-62A Walleye II ER/DL (825lb.)";;
 
-"weapons/us_1000lb_anm65_cone";"AN-M65A1 General-Purpose High-Explosive Bombs, Fin M129 (1000lb.)";;
-"weapons/us_1000lb_anm65_cone/short";"AN-M65A1 GPHE (1000lb.)";;
+"weapons/us_1000lb_anm65_cone";"AN-M65A1 General Purpose High-Explosive Bombs, Fin M129 (1000lb.)";;
+"weapons/us_1000lb_anm65_cone/short";"AN-M65A1 (1000lb.)";;
 
-"weapons/us_2000lbs_anm66";"AN-M66A2 General-Purpose High-Explosive Bombs (2000lb.)";;
-"weapons/us_2000lbs_anm66/short";"AN-M66A2 GPHE (2000lb.)";;
+"weapons/us_2000lbs_anm66";"AN-M66A2 General Purpose High-Explosive Bombs (2000lb.)";;
+"weapons/us_2000lbs_anm66/short";"AN-M66A2 (2000lb.)";;
 
-"weapons/us_2000lbs_anm66_cone";"AN-M66A2 General-Purpose High-Explosive Bombs (2000lb.)";;
-"weapons/us_2000lbs_anm66_cone/short";"AN-M66A2 GPHE (2000lb.)";;
+"weapons/us_2000lbs_anm66_cone";"AN-M66A2 General Purpose High-Explosive Bombs (2000lb.)";;
+"weapons/us_2000lbs_anm66_cone/short";"AN-M66A2 (2000lb.)";;
 
 "weapons/us_1600lb_ap_an_mk1";"AN-Mk1 Armor-Piercing High-Explosive Bombs (1600lb.)";;
 "weapons/us_1600lb_ap_an_mk1/short";"AN-Mk1 APHE (1600lb.)";;
@@ -1449,18 +1448,18 @@ noverify>";"<English>";
 "weapons/us_1600lb_ap_an_mk1_45/short";"AN-Mk1 APHE (1600lb.)";;
 
 "weapons/us_1000lbs";"AN-M65A1 General Purpose High-Explosive Bombs (1000lb.)";;
-"weapons/us_1000lbs/short";"AN-M65A1 GPHE (1000lb.)";;
+"weapons/us_1000lbs/short";"AN-M65A1 (1000lb.)";;
 
 "weapons/us_100lbs";"AN-M30A1 100lb. General Purpose High-Explosive Bombs";;
 
-"weapons/us_2000lbs";"AN-M66A2 General-Purpose High-Explosive Bombs (2000lb.)";;
-"weapons/us_2000lbs/short";"AN-M66A1 GPHE (2000lb.)";;
+"weapons/us_2000lbs";"AN-M66A2 General Purpose High-Explosive Bombs (2000lb.)";;
+"weapons/us_2000lbs/short";"AN-M66A1 (2000lb.)";;
 
 "weapons/us_500lbs";"AN-M64A1 General Purpose High Explosve Bombs (500lb.)";;
 "weapons/us_500lbs/short";"AN-M64A1 (500lb.)";;
 
 "weapons/us_500lb_mk_82_ldgp_air";"Mk82 Low-Drag General Purpose Ballute-Type Air-Retarded Bombs (500lb.)";;
-"weapons/us_500lb_mk_82_ldgp_air/short";"Mk82 LDGP AIR (500lb.)";;
+"weapons/us_500lb_mk_82_ldgp_air/short";"Mk82 AIR (500lb.)";;
 
 "weapons/us_250lb_mk_81_ldgp_snakeye";"Mk81 Snakeye High-Drag General Purpose Tail-Fin Air-Retarded Bombs (250lb.)";;
 "weapons/us_250lb_mk_81_ldgp_snakeye/short";"Mk81 Snakeye (250lb.)";;
@@ -1472,55 +1471,55 @@ noverify>";"<English>";
 "weapons/us_500lb_mk_82_ldgp_snakeye_default/short";"Mk82 Snakeye (500lb.)";;
 
 "weapons/us_1000lb_anm65a1";"AN-M65A1 Low-Drag General Purpose Bombs (1000lb.)";;
-"weapons/us_1000lb_anm65a1/short";"AN-M65A1 LDGP (1000lb.)";;
+"weapons/us_1000lb_anm65a1/short";"AN-M65A1 (1000lb.)";;
 
 "weapons/us_1000lb_anm65a1_default";"AN-M65A1 Low-Drag General Purpose Bombs (1000lb.)";;
-"weapons/us_1000lb_anm65a1_default/short";"AN-M65A1 LDGP (1000lb.)";;
+"weapons/us_1000lb_anm65a1_default/short";"AN-M65A1 (1000lb.)";;
 
 "weapons/us_100lb_anm30";"AN-M30A1 General Purpose High-Explosve Bombs (100lb.)";;
-"weapons/us_100lb_anm30/short";"AN-M30A1 GPHE (100lb.)";;
+"weapons/us_100lb_anm30/short";"AN-M30A1 (100lb.)";;
 
 "weapons/us_250lb_anm57";"AN-M57 General Purpose High-Explosive Bombs (250lb.)";;
-"weapons/us_250lb_anm57/short";"AN-M57 GPHE (250lb.)";;
+"weapons/us_250lb_anm57/short";"AN-M57 (250lb.)";;
 
 "weapons/us_250lb_anm57_default";"AN-M57 General Purpose High-Explosive Bombs (250lb.)";;
-"weapons/us_250lb_anm57_default/short";"AN-M57 GPHE (250lb.)";;
+"weapons/us_250lb_anm57_default/short";"AN-M57 (250lb.)";;
 
 "weapons/us_500lb_anm64a1";"AN-M64A1 General Purpose High-Explosive Bombs (500lb.)";;
-"weapons/us_500lb_anm64a1/short";"AN-M64A1 GPHE (500lb.)";;
+"weapons/us_500lb_anm64a1/short";"AN-M64A1 (500lb.)";;
 
 "weapons/us_1000lb_anm65a1_rod";"AN-M65A1 Light-Case General Purpose Bombs (1000lb.)";;
-"weapons/us_1000lb_anm65a1_rod/short";"AN-M65A1 LCGP (1000lb.)";;
+"weapons/us_1000lb_anm65a1_rod/short";"AN-M65A1 (1000lb.)";;
 
 "weapons/us_500lb_anm64a1_rod";"AN-M64A1 General Purpose High-Explosive Bombs (500lb.)";;
-"weapons/us_500lb_anm64a1_rod/short";"AN-M64A1 GPHE (500lb.)";;
+"weapons/us_500lb_anm64a1_rod/short";"AN-M64A1 (500lb.)";;
 
 "weapons/us_250lb_mk_81_ldgp";"Mk81 Low-Drag General Purpose Bombs (250lb)";;
-"weapons/us_250lb_mk_81_ldgp/short";"Mk81 LDGP (250lb.)";;
+"weapons/us_250lb_mk_81_ldgp/short";"Mk81 (250lb.)";;
 
 "weapons/us_500lb_mk_82_ldgp";"Mk82 Low-Drag General Purpose Bombs (500lb.)";;
-"weapons/us_500lb_mk_82_ldgp/short";"MK82 LDGP (500lb.)";;
+"weapons/us_500lb_mk_82_ldgp/short";"MK82 (500lb.)";;
 
 "weapons/us_500lb_mk_82_ldgp_default";"Mk82 Low-Drag General Purpose Bombs (500lb.)";;
-"weapons/us_500lb_mk_82_ldgp_default/short";"Mk82 LDGP (500lb.)";;
+"weapons/us_500lb_mk_82_ldgp_default/short";"Mk82 (500lb.)";;
 
 "weapons/us_1000lb_mk_83_ldgp";"Mk83 Low-Drag General Purpose Bombs (1000lb.)";;
-"weapons/us_1000lb_mk_83_ldgp/short";"Mk83 LDGP (1000lb.)";;
+"weapons/us_1000lb_mk_83_ldgp/short";"Mk83 (1000lb.)";;
 
 "weapons/us_1000lb_mk_83_ldgp_default";"Mk83 Low-Drag General Purpose Bombs (1000lb.)";;
-"weapons/us_1000lb_mk_83_ldgp_default/short";"Mk83 LDGP (1000lb.)";;
+"weapons/us_1000lb_mk_83_ldgp_default/short";"Mk83 (1000lb.)";;
 
 "weapons/us_2000lb_mk_84_ldgp";"Mk84 Low-Drag General Purpose Bombs (2000lb.)";;
-"weapons/us_2000lb_mk_84_ldgp/short";"Mk84 LDGP (2000lb.)";;
+"weapons/us_2000lb_mk_84_ldgp/short";"Mk84 (2000lb.)";;
 
 "weapons/us_3000lb_m118";"M118 Low-Drag Demolition Bombs (3000lb.)";;
-"weapons/us_3000lb_m118/short";"M118 LDDB (3000lb.)";;
+"weapons/us_3000lb_m118/short";"M118 (3000lb.)";;
 
 "weapons/us_4000lb_anm56_box";"AN-M56 Light-Case General Purpose Bombs (4000lb.)";;
-"weapons/us_4000lb_anm56_box/short";"AN-M56 LCGP (4000lb.)";;
+"weapons/us_4000lb_anm56_box/short";"AN-M56 (4000lb.)";;
 
 "weapons/us_2000lb_mk_84_ldgp_air";"Mk84 Low-Drag General Purpose Ballute-Type Air-Retarded Bombs (2000lb.)";;
-"weapons/us_2000lb_mk_84_ldgp_air/short";"Mk84 LDGP AIR (2000lb.)";;
+"weapons/us_2000lb_mk_84_ldgp_air/short";"Mk84 AIR (2000lb.)";;
 
 "weapons/us_500lb_gbu_62_jdam_er";"GBU-62 Joint Direct Attack Munition (Extended Range) GPS-Guided Glide Bomb (500lb.)";;
 "weapons/us_500lb_gbu_62_jdam_er/short";"GBU-62 JDAM-ER (500lb.)";;
@@ -1532,10 +1531,10 @@ noverify>";"<English>";
 "weapons/us_2000lb_gbu_64_jdam_er/short";"GBU-64 JDAM-ER (2000lb.)";;
 
 "weapons/us_750lb_m117_cone_45";"M117 Low-Drag Demolition Bombs, Cone 45 (750lb.)";;
-"weapons/us_750lb_m117_cone_45/short";"M117 LDDB (750lb.)";;
+"weapons/us_750lb_m117_cone_45/short";"M117 (750lb.)";;
 
 "weapons/us_1000lb_mk_83_ldgp_air";"Mk83 Low-Drag General Purpose Ballute-Type Air-Retarded Bomb (1000lb.)";;
-"weapons/us_1000lb_mk_83_ldgp_air/short";"Mk83 LDGP AIR (1000lb.)";;
+"weapons/us_1000lb_mk_83_ldgp_air/short";"Mk83 AIR (1000lb.)";;
 
 "weapons/us_500lb_mk77_mod2";"Mk77 Mod 2 Incendiary Napalm Bombs (750lb.)";;
 "weapons/us_500lb_mk77_mod2/short";"Mk77 INC (750lb.)";;
@@ -1568,16 +1567,81 @@ noverify>";"<English>";
 "weapons/us_750lb_mk77_mod0/short";"Mk77 INC (750lb.)";;
 
 //Bombs, GER
+"weapons/de_sc50";"50 kg SC50JA bomb";;
+"weapons/de_sc50_default";"50 kg SC50JA bomb";;
+"weapons/de_sc50_default/short";"SC50";;
+
+"weapons/de_sc250";"250 kg SC250JA bomb";;
+"weapons/de_sc250_default";"250 kg SC250JA bomb";;
+"weapons/de_sc250_default/short";"SC250";;
+
+"weapons/de_sc500";"500 kg SC500K bomb";;
+
+"weapons/de_sc_ag300";"300 kg SC AG bomb";;
+"weapons/de_sc_ag300/short";"300 kg SC AG";;
+
+"weapons/de_sc250_87";"250 kg SC250JA bomb";;
+
+"weapons/de_fx1400";"PC 1400 X (Fritz X)";;
+
+"weapons/de_hs_293a1";"HS 293 A-1 guided bomb";;
+"weapons/de_hs_293a1/short";"HS 293 A-1";;
+
+"weapons/de_sc500_87";"500 kg SC500K bomb";;
+
+"weapons/de_sc1800b";"1800 kg SC1800B bomb";;
+
+"weapons/de_sc1000";"1000 kg SC1000L2 bomb";;
+"weapons/de_sc1000_default";"1000 kg SC1000L2 bomb";;
+"weapons/de_sc1000_default/short";"SC1000";;
+
+"weapons/de_sd10a";"10 kg SD10C bomb";;
+
+"weapons/de_sd50";"50 kg SD50 bomb";;
+"weapons/de_sd50/short";"SD50";;
+
+"weapons/de_sd70";"70 kg SD70 bomb";;
+"weapons/de_sd70/short";"SD70";;
+
+"weapons/de_pc500_ap";"500 kg PC500 armor-piercing bomb";;
+"weapons/de_pc500_ap/short";"PC500";;
+
+"weapons/de_pd500_ap";"500 kg PD500 armor-piercing bomb";;
+"weapons/de_pd500_ap/short";"PD500";;
+
+"weapons/de_pc500_rs_ap";"500 kg PC500 RS armor-piercing rocket bomb";;
+"weapons/de_pc500_rs_ap/short";"PC500 RS";;
+
+"weapons/de_pc1000_ap";"1000 kg PC1000 armor-piercing bomb";;
+"weapons/de_pc1000_ap/short";"PC1000";;
+
+"weapons/de_pc1000_rs_ap";"1000 kg PC1000 RS armor-piercing rocket bomb";;
+"weapons/de_pc1000_rs_ap/short";"PC1000 RS";;
+
+"weapons/de_pc1600_ap";"1600 kg PC1600 armor-piercing bomb";;
+"weapons/de_pc1600_ap/short";"PC1600";;
+
+"weapons/de_pc1800_rs_ap";"1800 kg PC1800 RS armor-piercing rocket bomb";;
+"weapons/de_pc1800_rs_ap/short";"PC1800 RS";;
+
+"weapons/de_250_matra_25e";"250 kg Matra 25E bomb";;
+"weapons/de_250_matra_25e/short";"250 kg Matra 25E";;
+
+"weapons/de_sc2500";"2500 kg SC2500 bomb";;
+"weapons/de_sc2500/short";"SC2500";;
+
+"weapons/de_sb2500";"2500 kg SB2500 bomb";;
+"weapons/de_sb2500/short";"SB2500";;
 
 //Bombs, USSR
 
 //Bombs, GB
 "weapons/uk_paveway_iv";"Paveway IV Dual-Mode Laser-Guided Bombs (500lb.)";;
-"weapons/uk_paveway_iv/short";"Paveway IV DMLGB (500lb.)";;
+"weapons/uk_paveway_iv/short";"Paveway IV (500lb.)";;
 
 //Bombs, JP
 "weapons/us_750lb_m117_cone_45_japan";"JM117 Low-Drag Demolition Bombs, Cone 45 (750lb.)";;
-"weapons/us_750lb_m117_cone_45_japan/short";"JM117 LDDB (750lb.)";;
+"weapons/us_750lb_m117_cone_45_japan/short";"JM117 (750lb.)";;
 
 //Bombs, CN
 


### PR DESCRIPTION
v0.4.1d6-md5