### PR TITLE
v0.4.2d6-md6

### DIFF
--- a/Mod Files/syrup_units_gb.csv
+++ b/Mod Files/syrup_units_gb.csv
@@ -620,14 +620,14 @@
 "harrier_t10_1";"Harrier T.10";;
 "harrier_t10_2";"Harrier T.10";;
 #
-"saab_jas39c_south_africa_shop";"▄JAS 39C Gripen C";;
-"saab_jas39c_south_africa_0";"Saab AB | ▄JAS 39C Gripen C";;
-"saab_jas39c_south_africa_1";"▄JAS 39C Gripen C";;
+"saab_jas39c_south_africa_shop";"▄JAS 39C Gripen";;
+"saab_jas39c_south_africa_0";"Saab AB | ▄JAS 39C Gripen";;
+"saab_jas39c_south_africa_1";"▄JAS 39C Gripen";;
 "saab_jas39c_south_africa_2";"▄JAS 39C";;
 #
-"saab_jas39c_south_africa_missile_test_shop";"▄JAS 39C Gripen C";;
-"saab_jas39c_south_africa_missile_test_0";"Saab AB | ▄JAS 39C Gripen C";;
-"saab_jas39c_south_africa_missile_test_1";"▄JAS 39C Gripen C";;
+"saab_jas39c_south_africa_missile_test_shop";"▄JAS 39C Gripen";;
+"saab_jas39c_south_africa_missile_test_0";"Saab AB | ▄JAS 39C Gripen";;
+"saab_jas39c_south_africa_missile_test_1";"▄JAS 39C Gripen";;
 "saab_jas39c_south_africa__missile_test2";"▄JAS 39C";;
 #
 "tornado_gr1_shop";"▄Tornado GR.1";;

--- a/Mod Files/syrup_units_ger.csv
+++ b/Mod Files/syrup_units_ger.csv
@@ -291,7 +291,7 @@ noverify>";"<English>";;
 "f-84f_germany_2";"◄F-84F";;
 #
 "mig_23bn_shop";"◊MiG-23BN Flogger-H";;
-"mig_23bn_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23BN Flogger-H | Product 32-24B";;
+"mig_23bn_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23BN Flogger-H | Izdeliye 32-24B";;
 "mig_23bn_1";"◊MiG-23BN Flogger-H";;
 "mig_23bn_2";"◊MiG-23BN";;
 #
@@ -316,32 +316,32 @@ noverify>";"<English>";;
 "f-4f_late_2";"◄F-4F";;
 #
 "mig-21_mf_shop";"◊MiG-21MF Fishbed-J";;
-"mig-21_mf_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21MF Fishbed-J | Product 96F";;
+"mig-21_mf_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21MF Fishbed-J | Izdeliye 96F";;
 "mig-21_mf_1";"◊MiG-21MF Fishbed-J";;
 "mig-21_mf_2";"◊MiG-21MF";;
 #
 "mig-21_sps_k_shop";"◄MiG-21SPS-K Fishbed-F";;
-"mig-21_sps_k_0";"◄OKB-155 ""Mikoyan i Gurevich"" | MiG-21SPS-K Fishbed-F  | Product 94A";;
+"mig-21_sps_k_0";"◄OKB-155 ""Mikoyan i Gurevich"" | MiG-21SPS-K Fishbed-F  | Izdeliye 94A";;
 "mig-21_sps_k_1";"◄MiG-21SPS-K Fishbed-F";;
 "mig-21_sps_k_2";"◄MiG-21SPS-K";;
 #
 "mig-21_bis_sau_shop";"◊MiG-21bis-SAU Fishbed-N";;
-"mig-21_bis_sau_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis-SAU Fishbed-N | Product 75B";;
+"mig-21_bis_sau_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis-SAU Fishbed-N | Izdeliye 75B";;
 "mig-21_bis_sau_1";"◊MiG-21bis-SAU Fishbed-N";;
 "mig-21_bis_sau_2";"◊MiG-21bis-SAU";;
 #
 "mig-21_bis_lazur_shop";"◊MiG-21bis-Lazur Fishbed-L";;
-"mig-21_bis_lazur_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis-Lazur Fishbed-L | Product 75A";;
+"mig-21_bis_lazur_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis-Lazur Fishbed-L | Izdeliye 75A";;
 "mig-21_bis_lazur_1";"◊MiG-21bis-Lazur Fishbed-L";;
 "mig-21_bis_lazur_2";"◊MiG-21bis-Lazur";;
 #
 "mig_23mla_shop";"◊MiG-23MLA Flogger-G";;
-"mig_23mla_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Product 23-12A";;
+"mig_23mla_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Izdeliye 23-12A";;
 "mig_23mla_1";"◊MiG-23MLA Flogger-G";;
 "mig_23mla_2";"◊MiG-23MLA";;
 #
 "mig_23mf_germany_shop";"◊MiG-23MF Flogger-B";;
-"mig_23mf_germany_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23MF Flogger-B | Product 23-11M";;
+"mig_23mf_germany_0";"◊OKB-155 ""Mikoyan i Gurevich"" | MiG-23MF Flogger-B | Izdeliye 23-11M";;
 "mig_23mf_germany_1";"◊MiG-23MF Flogger-B";;
 "mig_23mf_germany_2";"◊MiG-23MF";;
 #
@@ -391,14 +391,14 @@ tornado_ids_de_assta1_killstreak_2;☢IDS-Tornado (ASSTA 1.0);;
 "ef_2000_block_10_2";"◄EF-2000 (P3Ea)";;
 #
 "mig_29_9_12_germany_shop";"◊MiG-29A Fulcrum-A";;
-"mig_29_9_12_germany_0";"◊OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-A | Product 9.12A";;
+"mig_29_9_12_germany_0";"◊OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-A | Izdeliye 9-12A";;
 "mig_29_9_12_germany_1";"◊MiG-29A Fulcrum-A";;
 "mig_29_9_12_germany_2";"◊MiG-29A";;
 #
-"mig_29_9_12g_shop";"◄MiG-29G Fulcrum-G";;
-"mig_29_9_12g_0";"◄OKB-155 ""Mikoyan"" | MiG-29G Fulcrum-G | Product 9.12A";;
-"mig_29_9_12g_1";"◄MiG-29G Fulcrum-G";;
-"mig_29_9_12g_2";"◄MiG-29G";;
+"mig_29_9_12g_shop";"◄MiG-29G Fulcrum-A";;
+"mig_29_9_12g_0";"◄OKB-155 ""Mikoyan"" | MiG-29G Fulcrum-A | Izdeliye 9-12A";;
+"mig_29_9_12g_1";"◄MiG-29G Fulcrum-A";;
+"mig_29_9_12g_2";"◄MiG-29A";;
 #
 "hunter_f58a_1971_switzerland_shop";"◌Hunter Mk.58A (1971)";;
 "hunter_f58a_1971_switzerland_0";"◌Hawker Aircraft, Ltd. | Hunter Mk.58A (1971)";;

--- a/Mod Files/syrup_units_it.csv
+++ b/Mod Files/syrup_units_it.csv
@@ -411,17 +411,17 @@
 "su_22m3_hungary_2";"◔Su-22M3";;
 #
 "mig-21_mf_hungary_shop";"◔MiG-21MF Fishbed-J";;
-"mig-21_mf_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-21MF Fishbed-J | Product 96F";;
+"mig-21_mf_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-21MF Fishbed-J | Izdeliye 96F";;
 "mig-21_mf_hungary_1";"◔MiG-21MF Fishbed-J";;
 "mig-21_mf_hungary_2";"◔MiG-21MF";;
 #
 "mig-21_bis_sau_hungary_shop";"◔MiG-21bis Fishbed-N";;
-"mig-21_bis_sau_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-21bis Fishbed-N | Product 75B";;
+"mig-21_bis_sau_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-21bis Fishbed-N | Izdeliye 75B";;
 "mig-21_bis_sau_hungary_1";"◔MiG-21bis Fishbed-N";;
 "mig-21_bis_sau_hungary_2";"◔MiG-21bis";;
 #
 "mig_23mf_hungary_shop";"◔MiG-23MF Flogger-B";;
-"mig_23mf_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-23MF Flogger-B | Product 23-11M";;
+"mig_23mf_hungary_0";"OKB-155 ""Mikoyan i Gurevich"" | ◔MiG-23MF Flogger-B | Izdeliye 23-11M";;
 "mig_23mf_hungary_1";"◔MiG-23MF Flogger-B";;
 "mig_23mf_hungary_2";"◔MiG-23MF";;
 #
@@ -436,7 +436,7 @@
 "f_16a_block_15_adf_italy_2";"⛨F-16A-15ADF";;
 #
 "mig_29_9_12b_hungary_shop";"◔MiG-29A Fulcrum-A";;
-"mig_29_9_12b_hungary_0";"OKB-155 ""Mikoyan"" | ◔MiG-29A Fulcrum-A | Product 9.12B";;
+"mig_29_9_12b_hungary_0";"OKB-155 ""Mikoyan"" | ◔MiG-29A Fulcrum-A | Izdeliye 9-12B";;
 "mig_29_9_12b_hungary_1";"◔MiG-29A Fulcrum-A";;
 "mig_29_9_12b_hungary_2";"◔MiG-29A";;
 #
@@ -470,13 +470,13 @@
 "ef_2000a_1";"⛨F-2000A Typhoon (P3Ea)";;
 "ef_2000a_2";"⛨F-2000A (P3Ea)";;
 #
-"saab_jas39c_hungary_shop";"◔JAS 39EBS Gripen C";;
-"saab_jas39c_hungary_0";"Saab AB | ◔JAS 39EBS Gripen C";;
-"saab_jas39c_hungary_1";"◔JAS 39EBS Gripen C";;
-"saab_jas39c_hungary_2";"◔JAS 39EBS";;
+"saab_jas39c_hungary_shop";"◔JAS 39C EBS Gripen ";;
+"saab_jas39c_hungary_0";"Saab AB | ◔JAS 39C Gripen | Export Baseline Standard";;
+"saab_jas39c_hungary_1";"◔JAS 39C EBS Gripen";;
+"saab_jas39c_hungary_2";"◔JAS 39C EBS";;
 #
 "mig_29_9_12_sniper_shop";"▄MiG-29A Sniper";;
-"mig_29_9_12_sniper_0";"Aerostar S.A. / DASA / Elbit Systems, Ltd. | ▄MiG-29A Fulcrum-A | Product 9-12A | Sniper Modernization Program (1997)";;
+"mig_29_9_12_sniper_0";"Aerostar S.A. / DASA / Elbit Systems, Ltd. | ▄MiG-29A Fulcrum-A | Izdeliye 9-12A | Sniper Modernization Program (1997)";;
 "mig_29_9_12_sniper_1";"▄MiG-29A Sniper";;
 "mig_29_9_12_sniper_2";"▄MiG-29A Sniper";;
 #
@@ -484,6 +484,11 @@
 "mb_326k_0";"Aermacchi | MB-326K Impala";;
 "mb_326k_1";"MB-326K Impala";;
 "mb_326k_2";"MB-326K";;
+#
+mb_326b_shop;MB-326B Impala;;
+mb_326b_0;Aermacchi | MB-326B Impala;;
+mb_326b_1;MB-326B Impala;;
+mb_326b_2;MB-326B;;
 #
 tornado_ids_de_assta1_italy_killstreak_shop;☢A-200A Tornado IDS;;
 tornado_ids_de_assta1_italy_killstreak_0;Panavia Aircraft GmbH | ☢A-200A Tornado | Interdictor/Strike;;

--- a/Mod Files/syrup_units_jp.csv
+++ b/Mod Files/syrup_units_jp.csv
@@ -616,7 +616,7 @@
 "f_16a_block_15_ocu_thailand_2";"▄B.Kh.19";;
 #
 "saab_jas39c_thailand_shop";"▄B.Kh.20 Gripen C";;
-"saab_jas39c_thailand_0";"Saab AB | ▄B.Kh.20 | JAS 39C Gripen C";;
+"saab_jas39c_thailand_0";"Saab AB | ▄B.Kh.20 | JAS 39C Gripen";;
 "saab_jas39c_thailand_1";"▄B.Kh.20 Gripen C";;
 "saab_jas39c_thailand_2";"▄B.Kh.20";;
 #
@@ -669,6 +669,11 @@ hawk_209_indonesia_shop;◥Hawk 209;;
 hawk_209_indonesia_0;British Aerospace plc | ◥Hawk 209;;
 hawk_209_indonesia_1;◥Hawk 209;;
 hawk_209_indonesia_2;◥Hawk 209;;
+#
+mig_29n_shop;▄MiG-29N Fulcrum-C;;
+mig_29n_0;"RSO Korporatsiya ""MiG"" | ▄MiG-29N Fulcrum-C | Izdeliye 9-12SD";;
+mig_29n_1;▄MiG-29N Fulcrum-C;;
+mig_29n_2;▄MiG-29N;;
 #
 "shop/group/f-86_japan_group";"▅F-86F Sabre";;
 "shop/group/f-86_japan_group";"▅F-86F Sabre";;

--- a/Mod Files/syrup_units_swe.csv
+++ b/Mod Files/syrup_units_swe.csv
@@ -275,14 +275,14 @@
 "saab_ja37di_f21_1";"JA 37DI Jaktviggen (F 21)";;
 "saab_ja37di_f21_2";"JA 37DI (F 21)";;
 #
-"saab_jas39a_shop";"JAS 39A Gripen A";;
-"saab_jas39a_0";"Saab AB | JAS 39A Gripen A (2011)";;
-"saab_jas39a_1";"JAS 39A Gripen A";;
+"saab_jas39a_shop";"JAS 39A Gripen";;
+"saab_jas39a_0";"Saab AB | JAS 39A Gripen (2011)";;
+"saab_jas39a_1";"JAS 39A Gripen";;
 "saab_jas39a_2";"JAS 39A";;
 #
-"saab_jas39c_shop";"JAS 39C Gripen C";;
-"saab_jas39c_0";"Saab AB | JAS 39C Gripen C (2011)";;
-"saab_jas39c_1";"JAS 39C Gripen C";;
+"saab_jas39c_shop";"JAS 39C Gripen";;
+"saab_jas39c_0";"Saab AB | JAS 39C Gripen (2011)";;
+"saab_jas39c_1";"JAS 39C Gripen";;
 "saab_jas39c_2";"JAS 39C";;
 #
 "fa_18c_finland_shop";"▄F-18C Hornet";;

--- a/Mod Files/syrup_units_ussr.csv
+++ b/Mod Files/syrup_units_ussr.csv
@@ -191,12 +191,12 @@
 "la-9_2";"La-9";;;
 #
 "la-7_shop";"La-7 Fin (1944)";;;
-"la-7_0";"OKB-301 ""Lavochkin"" | La-7 Fin | 1944 Production Standard";;;
+"la-7_0";"OKB-301 ""Lavochkin"" | La-7 Fin | 1944 Izdeliyeion Standard";;;
 "la-7_1";"La-7 Fin (1944)";;;
 "la-7_2";"La-7 (1944)";;;
 #
 "la-7b-20_shop";"La-7 Fin (1945)";;;
-"la-7b-20_0";"OKB-301 ""Lavochkin"" | La-7 | 1945 Production Standard Fin";;;
+"la-7b-20_0";"OKB-301 ""Lavochkin"" | La-7 | 1945 Izdeliyeion Standard Fin";;;
 "la-7b-20_1";"La-7 Fin (1945)";;;
 "la-7b-20_2";"La-7 (1945)";;;
 #
@@ -291,27 +291,27 @@
 "su_33_2";"Su-33";;;
 #
 "mig_23mld_shop";"MiG-23MLD Flogger-K";;;
-"mig_23mld_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLD Flogger-K | Product 23-18";;;
+"mig_23mld_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLD Flogger-K | Izdeliye 23-18";;;
 "mig_23mld_1";"MiG-23MLD Flogger-K";;;
 "mig_23mld_2";"MiG-23MLD";;;
 #
 "mig_23ml_shop";"MiG-23MLA Flogger-G";;;
-"mig_23ml_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Product 23-12A";;;
+"mig_23ml_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Izdeliye 23-12A";;;
 "mig_23ml_1";"MiG-23MLA Flogger-G";;;
 "mig_23ml_2";"MiG-23MLA";;;
 #
 "mig_29_9_13_shop";"MiG-29A Fulcrum-C";;;
-"mig_29_9_13_0";"OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-C | Product 9-13";;;
+"mig_29_9_13_0";"OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-C | Izdeliye 9-13";;;
 "mig_29_9_13_1";"MiG-29A Fulcrum-C";;;
 "mig_29_9_13_2";"MiG-29A";;;
 #
 "mig_29smt_9_19_shop";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E | Product 9-19";;;
+"mig_29smt_9_19_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E | Izdeliye 9-19";;;
 "mig_29smt_9_19_1";"MiG-29SMT Fulcrum-E";;;
 "mig_29smt_9_19_2";"MiG-29SMT";;;
 #
 "mig_29smt_9_19_missile_test_shop";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_missile_test_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E| Product 9-19";;;
+"mig_29smt_9_19_missile_test_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E| Izdeliye 9-19";;;
 "mig_29smt_9_19_missile_test_1";"MiG-29SMT Fulcrum-E";;;
 "mig_29smt_9_19_missile_test_2";"MiG-29SMT";;;
 #
@@ -346,27 +346,27 @@
 "su_25sm3_2";"Su-25SM3";;;
 #
 "mig_23m_shop";"MiG-23M Flogger-B";;;
-"mig_23m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23M Flogger-B | Product 23-11M";;;
+"mig_23m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23M Flogger-B | Izdeliye 23-11M";;;
 "mig_23m_1";"MiG-23M Flogger-B";;;
 "mig_23m_2";"MiG-23M";;;
 #
 "mig-21_smt_shop";"MiG-21SMT Fishbed-K";;;
-"mig-21_smt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SMT Fishbed-K | Product 50";;;
+"mig-21_smt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SMT Fishbed-K | Izdeliye 50";;;
 "mig-21_smt_1";"MiG-21SMT Fishbed-K";;;
 "mig-21_smt_2";"MiG-21SMT";;;
 #
 "mig-21_s_shop";"MiG-21SM Fishbed-J";;;
-"mig-21_s_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SM Fishbed-J | Product 95M";;;
+"mig-21_s_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SM Fishbed-J | Izdeliye 95M";;;
 "mig-21_s_1";"MiG-21SM Fishbed-J";;;
 "mig-21_s_2";"MiG-21SM";;;
 #
 "mig-21_bis_shop";"MiG-21bis Fishbed-L";;;
-"mig-21_bis_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis Fishbed-L | Product 75A";;;
+"mig-21_bis_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis Fishbed-L | Izdeliye 75A";;;
 "mig-21_bis_1";"MiG-21bis Fishbed-L";;;
 "mig-21_bis_2";"MiG-21bis";;;
 #
 "mig-21_pfm_shop";"MiG-21PFM Fishbed-D";;;
-"mig-21_pfm_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21PFM Fishbed-D | Product 94";;;
+"mig-21_pfm_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21PFM Fishbed-D | Izdeliye 94";;;
 "mig-21_pfm_1";"MiG-21PFM Fishbed-D";;;
 "mig-21_pfm_2";"MiG-21PFM";;;
 #
@@ -416,7 +416,7 @@
 "mig-19pt_2";"MiG-19PT";;;
 #
 "mig-21_f13_shop";"MiG-21F-13 Fishbed-C";;;
-"mig-21_f13_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21F-13 Fishbed-C | Product 74";;;
+"mig-21_f13_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21F-13 Fishbed-C | Izdeliye 74";;;
 "mig-21_f13_1";"MiG-21F-13 Fishbed-C";;;
 "mig-21_f13_2";"MiG-21F-13";;;
 #
@@ -864,6 +864,11 @@ mig_25pd_shop;MiG-25PD Foxbat-E;;;
 mig_25pd_0;"OKB-155 ""Mikoyan i Gurevich"" | MiG-25PD Foxbat-E";;;
 mig_25pd_1;MiG-25PD Foxbat-E;;;
 mig_25pd_2;MiG-25PD;;;
+#
+su_30sm2_shop;Su-30SM2 Flanker-H;;;
+su_30sm2_0;"PAO Kompaniya ""Sukhoi"" | Su-30SM2 Flanker-H";;;
+su_30sm2_1;Su-30SM2 Flanker-H;;;
+su_30sm2_2;Su-30SM2;;;
 #
 "shop/group/ar_group";"Ar-2/SB-2";;;
 "shop/group/db_3_group";"DB-3B/Il-4 Bob";;;

--- a/Mod Files/syrup_weapons.csv
+++ b/Mod Files/syrup_weapons.csv
@@ -1957,6 +1957,9 @@ weapons/su_grom_1/short;Kh-36 Grom-E1 [600kg]
 weapons/su_grom_2;Kh-36 Grom-E2 GLONASS-Guided Glide Bomb [600kg]
 weapons/su_grom_2/short;Kh-36 Grom-E2 [600kg]
 #
+weapons/su_grom_e2;Kh-36 Grom-E2 GLONASS-Guided Glide Bomb [600kg]
+weapons/su_grom_e2/short;Kh-36 Grom-E2 [600kg]
+#
 weapons/su_fab_1000m_44;FAB-1000 High-Explosive Bomb - Model 1944 [1000kg]
 weapons/su_fab_1000m_44/short;FAB-1000M-44 [1000kg]
 #


### PR DESCRIPTION
changed the names of some new dev server aircraft (Su-30SM2, MiG-29N), renamed the Grom-E2 (model of Grom on the export Flankers), and changed the names of the Gripens