### PR TITLE
0.4.3d1-md1

### DIFF
--- a/Mod Files/localization.blk
+++ b/Mod Files/localization.blk
@@ -1,4 +1,5 @@
 ps4override:t="%lang/ps4_specific.csv"
+ps5override:t="%lang/ps5_specific.csv"
 xboxOneoverride:t="%lang/xboxOne_specific.csv"
 regional:t="%langRegional/special_events.csv"
 regional:t="%langRegional/tournaments.csv"
@@ -66,6 +67,7 @@ locTable{
   file:t="%lang/_missing.csv"
   file:t="%lang/_online.csv"
   file:t="%lang/pc_UiMessages.csv"
+  file:t="%lang/inf.csv"
   file:t="%lang/modded/syrup_units_usa.csv"
   file:t="%lang/modded/syrup_units_ussr.csv"
   file:t="%lang/modded/syrup_units_it.csv"
@@ -84,7 +86,7 @@ locTable{
   file:t="%lang/modded/syrup_version.csv"
   file:t="%lang/modded/syrup_sensors.csv"
   file:t="%lang/modded/syrup_ui.csv"
-
+  file:t="%lang/modded/syrup_infantry.csv"
 }
 
 locTableFull{
@@ -92,6 +94,10 @@ locTableFull{
   file:t="%lang/_common_languages.csv"
   file:t="%lang/missions_versus.csv"
   file:t="%lang/missions_locations.csv"
+  file:t="%lang/ui.csv"
+  file:t="%lang/pc_UiMessages.csv"
+  file:t="%lang/units_weaponry.csv"
+  file:t="%lang/menu.csv"
 }
 
 full_translation{
@@ -261,6 +267,8 @@ text_translation{
     lang:t="Turkish"
     lang:t="Chinese"
     lang:t="Korean"
+    lang:t="Ukrainian"
+    lang:t="Vietnamese"
   }
 
   ps5{
@@ -278,6 +286,8 @@ text_translation{
     lang:t="Turkish"
     lang:t="Chinese"
     lang:t="Korean"
+    lang:t="Ukrainian"
+    lang:t="Vietnamese"
   }
 }
 

--- a/Mod Files/syrup_ai_units.csv
+++ b/Mod Files/syrup_ai_units.csv
@@ -1,5 +1,4 @@
-"<ID|readonly|
-noverify>";"<English>";
+"<ID|readonly|noverify>";"<English>";
 
 "ships/uss_cv_immortal_0";"USS Immortal";;
 "ships/uss_cv_immortal_1";"USS Immortal";;

--- a/Mod Files/syrup_infantry.csv
+++ b/Mod Files/syrup_infantry.csv
@@ -1,0 +1,728 @@
+"<ID|readonly|noverify>";"<English>"
+hotkeys/ID_HUMAN_JUMP;Jump
+hotkeys/ID_HUMAN_SPRINT;Fast run
+hotkeys/ID_HUMAN_FIRE_HEADER;Weaponry
+hotkeys/ID_FIRE_HUMAN;Fire from the main calibre gun
+hotkeys/ID_FIRE_HUMAN_SECONDARY_GUN;Fire from secondary guns
+hotkeys/ID_FIRE_HUMAN_MACHINE_GUN;Fire from the underbarrel grenade launcher
+hotkeys/ID_FIRE_HUMAN_SPECIAL_GUN;Fire from special guns
+hotkeys/ID_SELECT_HUMAN_GUN_RESET;Reset weapon selection
+hotkeys/ID_SELECT_HUMAN_GUN_MACHINEGUN;Select the machine gun
+hotkeys/ID_SELECT_HUMAN_GUN_PRIMARY;Select the primary weapon
+hotkeys/ID_SELECT_HUMAN_GUN_SECONDARY;Select the secondary weapon
+hotkeys/ID_HUMAN_SMOKE_GRENADE;Smoke grenades
+hotkeys/ID_WEAPON_LOCK_HUMAN;Weapon lock
+hotkeys/ID_SENSOR_SWITCH_HUMAN;Switch Radar/IRST search on/off
+hotkeys/ID_SENSOR_TARGET_SWITCH_HUMAN;Select the Radar/IRST target to lock
+hotkeys/ID_SENSOR_TARGET_LOCK_HUMAN;Lock the Radar/IRST on the target
+hotkeys/ID_HUMAN_NIGHT_VISION;Night vision mode
+hotkeys/ID_HUMAN_THERMAL_WHITE_IS_HOT;Changing the color scheme of the thermal sight
+hotkeys/ID_HUMAN_TOGGLE_RANGEFINDER;Rangefinder
+hotkeys/ID_HUMAN_VIEW_HEADER;Camera control
+hotkeys/ID_TOGGLE_VIEW_HUMAN;Sniper mode
+hotkeys/ID_TARGETING_HOLD_HUMAN;Target tracking
+hotkeys/ID_HUMAN_OTHER_HEADER;Miscellaneous
+hotkeys/ID_START_SUPPORT_PLANE_HUMAN;UAV Launch
+hotkeys/ID_SUPPORT_PLANE_ORBITING_HUMAN;Hover
+hotkeys/ID_SUBMARINE_SWITCH_FUSE_MODE;Switch fuze mode
+hotkeys/ID_SHIP_SWITCH_ACTIVE_SONAR;Sonar mode on/off
+hotkeys/ID_SHIPS_TOGGLE_HYDROPHONE_MODE;Hydrophone mode on/off
+hotkeys/ID_ENABLE_TARGET_TRACKING_TANK;Enable ATT
+hotkeys/ID_HUMAN_ORDERS_MENU;Squad orders menu
+hotkeys/ID_HUMAN_WEAPON_MENU;Weapon control menu: switching fire modes, using modules (underbarrel weapon, laser sight, flashlight)
+hotkeys/ID_HUMAN_MAIN_WEAPON;Switching between main weapon and module
+hotkeys/ID_HUMAN_SELECT_PREV_SOLDIER;Select previos soldier
+hotkeys/ID_HUMAN_SELECT_NEXT_SOLDIER;Select next soldier
+hotkeys/ID_HUMAN_CONTEXT_COMMAND_NEXT_SOLDIER;Select next soldier
+hotkeys/ID_HUMAN_CONTEXT_COMMAND_NEXT_POSE;Change selected soldier pose
+hotkeys/ID_HUMAN_CONTEXT_COMMAND;(hold the button) choose the location of the soldier. Order will be given if you release the button.
+hotkeys/ID_CREW_SWITCH_CONTROL_NEXT;Switch member
+hotkeys/ID_GRENADE_THROW_HEADER;Throw grenade
+hotkeys/ID_HUMAN_WEAP_MOD_TOGGLE;Underbarrel grenade launcher mode on/off
+hotkeys/ID_HUMAN_LASER_TOGGLE;Laser mode on/off
+hotkeys/ID_HUMAN_FLASH_LIGHT_TOGGLE;Flashlight mode on/off
+hotkeys/ID_HUMAN_FIRING_MOD_NEXT;Switch fire modes
+hotkeys/ID_TARGET_CAMERA_HUMAN_DRONE;Tracking Camera: Enemy
+hotkeys/ID_HUMAN_SHOOT;Shooting or using
+hotkeys/ID_HUMAN_AIM;Aiming or capturing
+hotkeys/ID_HUMAN_CROUCH;Sit down
+hotkeys/ID_HUMAN_CRAWL;Lie down
+hotkeys/ID_HUMAN_RELOAD;Reload gun
+hotkeys/ID_HUMAN_HOLD_BREATH;Hold breath
+hotkeys/ID_HUMAN_BIPODTOGGLE;Mount on bipod
+hotkeys/ID_HUMAN_NEXT_ZOOM;Change zoom
+hotkeys/ID_HUMAN_THROW;Throw grenade
+hotkeys/ID_HUMAN_WEAP_AMMO_TOGGLE;Change ammunition
+hotkeys/ID_CONTROL_MODE_HUMAN_UAV;Hover mode
+hotkeys/ID_LOCK_TARGETING_AT_POINT_HUMAN_UAV;Sight stabilization
+hotkeys/ID_UNLOCK_TARGETING_AT_POINT_HUMAN_UAV;Disable sight stabilization
+hotkeys/ID_HUMAN_UAV;UAV
+hotkeys/ID_TOGGLE_VIEW_HUMAN_UAV;Toggle View
+hotkeys/ID_HUMAN_NEXT_AFTER_DEATH;Switch to next
+hotkeys/ID_REPAIR_HUMAN;Repair
+hotkeys/ID_HUMAN_SHOOT_MELEE;Melee strike
+hotkeys/ID_HUMAN_USE_MEDKIT;Use medkit
+controls/human_wheelmenu_x;Radial menu navigation (X-axis)
+controls/human_wheelmenu_y;Radial menu navigation (Y-axis)
+controls/hold_button_for_fast_sprint;Hold for fast run
+controls/aim_time_nonlinearity_human;Gamepad aim acceleration
+controls/aim_acceleration_delay_human;Aim acceleration delay
+controls/help/human_move;The direction of movement
+controls/help/squad_info;Under your command, you have up to 5 soldiers who follow you unless you give them another order.
+controls/help/controlledHuman;Soldier under direct control
+controls/help/humanForOrder;Soldier chosen for the order
+controls/help/humanSlotInfo;"Above: a special weapon or item carried by a soldier.
+Bottom: type of explosive.
+You can give an order to use them."
+controls/help/changeHumanPose;Changes the soldier's turn
+controls/help/humanChangeInfo;Switch to soldier (1 ... 5) in the squad.
+controls/help/humanHoldPosition;A soldier holding a position effectively controls the specified direction.
+controls/human_mouse_aim_x;Infantryman aiming (X-axis)
+controls/human_mouse_aim_y;Infantryman aiming (Y-axis)
+controls/ID_HUMAN_UAV;Drone Control
+controls/human_uav_roll;Roll axis
+controls/human_uav_pitch;Pitch axis
+controls/human_uav_yaw;Yaw axis
+controls/human_uav_throttle;Throttle axis
+controls/human_uav_climb;Hover height
+controls/ID_CONTROL_MODE_HUMAN_UAV;Hover mode
+hotkeys/human_mouse_aim_x;Infantryman aiming (X-axis)
+hotkeys/human_mouse_aim_y;Infantryman aiming (Y-axis)
+controls/human_camx;View in battle - Infantry (X-axis)
+controls/human_camy;View in battle - Infantry (Y-axis)
+hotkeys/ID_HUMAN_MOVE_HEADER;Movement
+hotkeys/ID_HUMAN_CONTROL_HEADER;Infantry
+controls/human_walk;Move axis
+controls/human_strafe;Strafe axis
+infantry_camouflage;Soldiers camouflage
+exp_reasons/kill_human;Infantry neutralized
+unit_type/human;Infantry
+flightmenu/btnBailoutHuman;Get rid of the soldier
+flightmenu/questionBailoutHuman;Are you sure you want to get rid of the soldier?
+mainmenu/firearms;Firearms
+mainmenu/type_human;Firearm
+crew/vision;Attentiveness
+crew/mobility;Mobility
+crew/weapon_handling;Weapon handling
+crew/hpMult;Vitality
+crew/enduranceMult;Endurance
+crew/longerBreathHolding;Breath holding
+crew/medkitHealingPowerMult;Medical skills
+crew/visionSpottingDistanceMultiplier;Target detection
+crew/visionSpottingMultiplier;Target identification
+crew/runSpeedMult;Run speed
+crew/aimSpeedMult;Aim speed
+crew/bombPlantSpeedMult;Bomb planting speed
+crew/weaponChangeSpeedMult;Weapon change speed
+crew/poseChangeSpeedMult;Pose change speed
+crew/reloadSpeedMult;Reload speed
+crew/horizontalRecoilMult;Horizontal recoil resistance
+crew/verticalRecoilMult;Vertical recoil resistance
+crew/weaponTurningSpeedMult;Weapon turning speed
+crew/weaponSwayForceMult;Weapon stability
+crew/squadAdditionalSoldierCount;Soldier count
+crew/vitality/hpMult/tooltip;
+crew/vitality/enduranceMult/tooltip;
+crew/vitality/longerBreathHolding/tooltip;
+crew/vitality/medkitHealingPowerMult/tooltip;
+crew/vision/visionSpottingDistanceMultiplier/tooltip;
+crew/vision/visionSpottingMultiplier/tooltip;
+crew/mobility/runSpeedMult/tooltip;
+crew/mobility/aimSpeedMult/tooltip;
+crew/mobility/bombPlantSpeedMult/tooltip;
+crew/mobility/weaponChangeSpeedMult/tooltip;
+crew/mobility/poseChangeSpeedMult/tooltip;
+crew/weapon_handling/reloadSpeedMult/tooltip;
+crew/weapon_handling/horizontalRecoilMult/tooltip;
+crew/weapon_handling/verticalRecoilMult/tooltip;
+crew/weapon_handling/weaponTurningSpeedMult/tooltip;
+crew/weapon_handling/weaponSwayForceMult/tooltip;
+crew/groundService/squadAdditionalSoldierCount/tooltip;
+multiplayer/human_kills;Infantry Neutralized
+expEventScore/killHuman;Neutralization of infantry
+msgbox/applyToAllInfantrySkins;"Are you sure you want to apply camouflage
+ {skin} for BR({br}) {location}, {team}
+ to all firearms?"
+mainmenu/changeFirearm;Change Firearm
+hint/humanPickUpWeaponAmmo;Retrieve Ammo
+hint/humanUse;Use
+hint/humanPickUp;Pick Up
+hint/humanThrowBack;Throw grenade back
+hint/humanSwitchWeapons;Switch Weapons
+hint/humanOpenDoor;Open Door
+hint/humanCloseDoor;Close Door
+hint/humanOpenWindow;Open Window
+hint/humanCloseWindow;Close Window
+hints/drone/cooldown_for_launch;Cooldown: {seconds} seconds
+hints/drone_switch_control_mode;Deactivate Hover
+hint/medkitUsage;{{ID_HUMAN_USE_MEDKIT}} Use Medkit
+hint/bleeding_tip;Stop Bleeding
+hint/burning_tip;Extinguish Fire
+hint/soldier_switch_already_under_control;This soldier is already under your control.
+hint/soldier_switch_not_active;This soldier is not active anymore.
+hint/soldier_switch_wrong_index;You only have {numSoldiers} soldiers in your squad.
+hint/context_command/no_alive_squadmates;No active soldiers in squad.
+hint/context_command/all_orders_canceled;All orders cancelled.
+hint/context_command/personal_order_canceled;Personal order cancelled.
+hint/squad_orders/soldier_reports_failed_to_throw_grenade;The soldier failed to throw a grenade to the specified point.
+hint/squad_orders/no_way_to_throw_grenade_nobody_can_reach;The soldier cannot throw a grenade to the specified point.
+hint/squad_orders/soldier_reports_failed_to_attack_vehicle;The soldier cannot attack the specified vehicle.
+hint/personal_context_command_canceled/too_far;Personal order cancelled. You are too far from your squadmate.
+hint/squad/next_soldier_after_death;Next Soldier
+hint/hold_breath_to_aim;{{ID_HUMAN_HOLD_BREATH}} Hold Breath
+hint/next_variable_zoom_tip;Change Magnification
+squad_orders/frag_grenade;Frag
+squad_orders/smoke_grenade;Smoke
+squad_orders/flash_grenade;Flash
+squad_orders/cancel_mate_order;Cancel Order
+squad_orders/cancel_orders;Cancel All Orders
+squad_orders/orders_menu;Squad Actions...
+squad_orders/attack_vehicle;Attack Vehicle
+squad_orders/select_specific_soldier;Take Control Of Soldier
+weapon_menu/human/header;Weapon Menu
+weapon_menu/fire_mods/title;Fire Modes
+weapon_menu/fire_mods/switch;Switch Fire Mode
+weapon_menu/fire_mods/bolt_action;Manual
+weapon_menu/fire_mods/full_auto;Auto
+weapon_menu/fire_mods/full_auto_slow;Auto (Low RPM)
+weapon_menu/fire_mods/semi_auto;Semi
+weapon_menu/fire_mods/semi_auto_2_shots;Burst [2]
+weapon_menu/fire_mods/semi_auto_3_shots;Burst [3]
+weapon_menu/fire_mods/no_fire_mods;No Alternate Fire Modes
+weapon_menu/unbarrel/activate_unbarrel_gun;Select Underbarrel Grenade Launcher
+weapon_menu/unbarrel/deactivate_unbarrel_gun;Deselect Underbarrel Grenade Launcher
+weapon_menu/unbarrel/no_unbarrel_mode;No Underbarrel
+weapon_menu/laser/activate;Laser On
+weapon_menu/laser/deactivate;Laser Off
+weapon_menu/laser/no_laser_mod;No Laser Sight
+weapon_menu/flashlight/activate;Flashlight On
+weapon_menu/flashlight/deactivate;Flashlight Off
+weapon_menu/flashlight/no_flashlight_mod;No Flashlight
+death/bulletHit;Bullet Hit
+death/headshotHit;Headshot Hit
+death/meleeHit;Melee Hit
+death/bleedOut;Bleeding
+death/fallDmg;Fall Damage
+death/ranOver;Roadkill
+death/nearbyExplosion;Explosion
+death/humanDrown;Drowned
+death/mapArea;Left The Battlefield
+hint/miningWall;Mine Wall
+hint/reassemblingWall;Reassemble Wall
+hints/gun_needs_bipod;Bipod Required
+hints/place_bipod;Mount Weapon
+hints/drone/respawn_is_missing;No valid drone spawnpoint.
+hints/drone/bleeding_warning;Operator Injured
+hints/drone/not_availble_in_mission;Not available in the mission.
+hints/drone/lost_signal;Signal Lost
+hints/drone/out_of_area;Out of Signal Range
+hints/drone/near_area_border;Signal Range Boundary
+hints/drone/weak_signal;Weak Signal
+hints/resupply/medkit_box_refill;Refill Medkits
+hints/resupply/medkit_box_item_is_full;Maximum Medkits
+hints/resupply/useful_box_empty;The box is empty.
+hints/resupply/enemy_crate;Enemy Box
+hints/resupply/explosive_box_refill;Refill Explosives
+hints/resupply/ammo_box_refill;Refill Ammo
+hints/resupply/armor_box_refill;Restore Armor
+hints/resupply/ammo_full;Maximum Ammo
+modification/scope_aimpoint_pro_red_dot;Aimpoint Pro
+modification/scope_aimpoint_pro_red_dot/desc;Installs an Aimpoint Pro red dot sight on the main weapon.
+modification/scope_trijicon_rmr_red_dot;Trijicon RMR
+modification/scope_trijicon_rmr_red_dot/desc;Installs a Trijicon RMR micro red dot sight on the main weapon.
+modification/scope_vzor_red_dot;Vzor
+modification/scope_vzor_red_dot/desc;Installs a Vzor red dot sight on the main weapon.
+modification/scope_aimpoint_acro_p2_red_dot;Aimpoint Acro P-2
+modification/scope_aimpoint_acro_p2_red_dot/desc;Installs an Aimpoint Acro P-2 red dot sight on the main weapon.
+modification/scope_m68_cco;M68 CCO
+modification/scope_m68_cco/desc;Installs an M68 Close Combat Optic on the main weapon.
+modification/scope_1p63;1P63
+modification/scope_1p63/desc;Installs a 1P63 red dot sight on the main weapon.
+modification/scope_ekp_8_18_cobra;EKP-8-18
+modification/scope_ekp_8_18_cobra/desc;"Installs an EKP-8-18 ""Kobra"" red dot sight on the main weapon."
+modification/scope_exps3;EXPS3
+modification/scope_exps3/desc;Installs an EXPS3 holographic sight on the main weapon.
+modification/scope_1p87;1P87
+modification/scope_1p87/desc;Installs a 1P87 holographic sight on the main weapon.
+modification/scope_scp_t4iecdq;Leapers UTG Accushot
+modification/scope_scp_t4iecdq/desc;Installs a Leapers UTG AccuShot 4x scope on the main weapon.
+modification/scope_pso1_ak_4x;PSO-1
+modification/scope_pso1_ak_4x/desc;Installs a PSO-1 4x scope on the main weapon.
+modification/scope_acog_ta31;TA31 ACOG
+modification/scope_acog_ta31/desc;Installs a TA31 Advanced Combat Optical Gunsight on the main weapon.
+modification/scope_vortex_lpvo;Vortex LPVO
+modification/scope_vortex_lpvo/desc;Installs a Vortex Low-Power Variable Optic on the main weapon.
+modification/scope_sig_tango6_x6;Sig Tango6T
+modification/scope_sig_tango6_x6/desc;Installs a Sig Tango6T low-power variable optic on the main weapon.
+modification/scope_an_pas;AN/PAS-13
+modification/scope_an_pas/desc;Installs an AN/PAS-13 thermal imaging sight on the main weapon.
+modification/scope_scotopia_s350f;Scotopia PTRS
+modification/scope_scotopia_s350f/desc;Installs a Scotopia Precision Thermal Rifle Scope on the main weapon.
+modification/scope_shakhin;Cyclone Shakhin
+modification/scope_shakhin/desc;Installs a Cyclone Shakhin thermal imaging sight on the main weapon.
+modification/tactical_flashlight;Flashlight
+modification/tactical_flashlight/desc;Installs a tactical flashlight on the main weapon.
+modification/tactical_laser_us;Laser
+modification/tactical_laser_us/desc;Installs a tactical laser pointer on the main weapon.
+modification/tactical_laser_ussr;Laser
+modification/tactical_laser_ussr/desc;Installs a tactical laser pointer on the main weapon.
+modification/tactical_block_us;Advanced Target Pointer
+modification/tactical_block_us/desc;Installs an advanced target pointer on the main weapon.
+modification/tactical_block_ussr;Advanced Target Pointer
+modification/tactical_block_ussr/desc;Installs an advanced target pointer on the main weapon.
+modification/muzzle_223cb_compensator;223CB
+modification/muzzle_223cb_compensator/desc;Installs a 223CB muzzle brake on the main weapon.
+modification/muzzle_m11_sd_compensator;M11-SD
+modification/muzzle_m11_sd_compensator/desc;Installs an M11 Severe-Duty muzzle brake on the main weapon.
+modification/muzzle_vector_vr_13_compensator;Vector VR-13
+modification/muzzle_vector_vr_13_compensator/desc;Installs a Vector VR-13 muzzle brake on the main weapon.
+modification/muzzle_zenith_dtk_3_compensator;Zenith DTK-3
+modification/muzzle_zenith_dtk_3_compensator/desc;Installs a Zenith DTK-3 muzzle brake on the main weapon.
+modification/muzzle_socom556_suppressor;Suppressor
+modification/muzzle_socom556_suppressor/desc;Installs a suppressor on the main weapon.
+modification/muzzle_xm5_suppressor;Suppressor
+modification/muzzle_xm5_suppressor/desc;Installs a suppressor on the main weapon.
+modification/muzzle_m110a1_suppressor;Suppressor
+modification/muzzle_m110a1_suppressor/desc;Installs a suppressor on the main weapon.
+modification/muzzle_gls_mac_supressor;Suppressor
+modification/muzzle_gls_mac_supressor/desc;Installs a muzzle brake on the main weapon.
+modification/muzzle_hexagon_suppressor;Suppressor
+modification/muzzle_hexagon_suppressor/desc;Installs a suppressor on the main weapon.
+modification/muzzle_rotor43_svdm_suppressor;Suppressor
+modification/muzzle_rotor43_svdm_suppressor/desc;Installs a suppressor on the main weapon.
+modification/muzzle_pp_19_suppressor;Suppressor
+modification/muzzle_pp_19_suppressor/desc;Installs a suppressor on the main weapon.
+modification/grip_vertical_tangodown;TangoDown M-LOK
+modification/grip_vertical_tangodown/desc;Installs a TangoDown M-LOK vertical front grip on the main weapon.
+modification/grip_vertical_utg_5_position;UTG-5
+modification/grip_vertical_utg_5_position/desc;Installs a UTG-5 vertical front grip on the main weapon.
+modification/grip_vertical_rk2;ZenitCo RK-2
+modification/grip_vertical_rk2/desc;Installs a ZenitCo RK-2 vertical front grip on the main weapon.
+modification/grip_vertical_utg_qd;UTG QD
+modification/grip_vertical_utg_qd/desc;Installs a UTG QD vertical front grip on the main weapon.
+modification/grip_vertical_molot;Molot
+modification/grip_vertical_molot/desc;Installs a Molot vertical front grip on the main weapon.
+modification/grip_angled_magpul;Magpul AFG
+modification/grip_angled_magpul/desc;Installs a Magpul AFG angled front grip on the main weapon.
+modification/grenade_launcher_m320;M320
+modification/grenade_launcher_m320/desc;Installs an M320 underbarrel grenade launcher on the main weapon.
+modification/grenade_launcher_gp_34;GP-34
+modification/grenade_launcher_gp_34/desc;Installs a GP-34 grenade launcher on the main weapon.
+modification/5_56mm_tracer_ammo_belt;Tracers
+modification/5_56mm_tracer_ammo_belt/desc;Loads magazines with additional tracer cartridges.
+modification/5_56mm_ap_ammo_belt;Armor-Piercing
+modification/5_56mm_ap_ammo_belt/desc;Loads magazines with additional armor-piercing cartridges.
+modification/magazine_magpul_pmag_30_round;Magpul PMAG 30
+modification/magazine_magpul_pmag_30_round/desc;Installs the Magpul PMAG 30 30-round light plastic magazine on the main weapon.
+modification/magazine_magpul_pmag_40_round;Magpul PMAG 40
+modification/magazine_magpul_pmag_40_round/desc;Installs a Magpul PMAG 40 40-round light plastic magazine on the main weapon.
+modification/magazine_magpul_pmag_60_round;Magpul PMAG 60
+modification/magazine_magpul_pmag_60_round/desc;Installs a Magpul PMAG 60 60-round light plastic magazine on the main weapon.
+modification/shotgun_mossberg_590;Mossberg 590
+modification/shotgun_mossberg_590/desc;Allows you to additionally arm one of the soldiers in your squad with a shotgun.
+modification/shotgun_ks_p;KS-P 18.5
+modification/shotgun_ks_p/desc;Allows you to additionally arm one of the soldiers in your squad with a shotgun.
+modification/machinegun_m240;M240B
+modification/machinegun_m240/desc;Allows you to additionally arm one of the soldiers in your squad with a general purpose machine gun.
+modification/machinegun_reapr;REAPR
+modification/machinegun_reapr/desc;Allows you to additionally arm one of the soldiers in your squad with a general purpose machine gun.
+modification/machinegun_pkp_pecheneg;PKP Pecheneg
+modification/machinegun_pkp_pecheneg/desc;Allows you to additionally arm one of the soldiers in your squad with a general purpose machine gun.
+modification/at_laucher_rpg_7;RPG-7
+modification/at_laucher_rpg_7/desc;Allows you to additionally arm one of the soldiers in your squad with an anti-tank grenade launcher.
+modification/at_laucher_at_4;AT-4
+modification/at_laucher_at_4/desc;Allows you to additionally arm one of the soldiers in your squad with an anti-tank grenade launcher.
+modification/mpads_igla;9K38 Igla
+modification/mpads_igla/desc;Allows you to additionally arm one of the soldiers in your squad with a man-portable air-defence system.
+modification/mpads_stinger;FIM-92A
+modification/mpads_stinger/desc;Allows you to additionally arm one of the soldiers in your squad with a man-portable air-defence system.
+modification/strike_drone;Loitering Munition
+modification/strike_drone/desc;Allows you to additionally arm one of the soldiers in your squad with a kamikaze drone.
+modification/fpv_drone;FPV Drone
+modification/fpv_drone/desc;Allows you to additionally arm one of the soldiers in your squad with a FPV drone.
+modification/stun_grenade;Stun Grenade
+modification/stun_grenade/desc;Allows you to equip soldiers in your squad with stun grenades.
+modification/smoke_grenade;Smoke Grenade
+modification/smoke_grenade/desc;Allows you to equip soldiers in your squad with smoke grenades.
+modification/explosive_charge;Explosive Charge
+modification/explosive_charge/desc;Allows you to equip soldiers in your squad with remote detonation charges.
+modification/sidearms_pistol_mp_443;Sidearms
+modification/sidearms_pistol_mp_443/desc;Adds pistols to the soldiers' equipment.
+modification/sidearms_pistol_beretta_m9;Sidearms
+modification/sidearms_pistol_beretta_m9/desc;Adds pistols to the soldiers' equipment.
+modification/human_medkit;Extra Medkit
+modification/human_medkit/desc;Increases the number of individual first aid kits for each soldier in the squad.
+modification/bulletproof_vest_empty;No Armor
+modification/bulletproof_vest_default;Default Armor
+modification/bulletproof_vest_default/desc;
+modification/bulletproof_vest_light;Light Armor
+modification/bulletproof_vest_light_ghillie;Ghillie Suit
+modification/bulletproof_vest_medium;Medium Armor
+modification/bulletproof_vest_heavy;Heavy Armor
+modification/category/equipment_grenade;Grenades
+modification/category/equipment_special;Special
+modification/category/equipment_common;Equipment
+modification/item__weight;{value} to weight
+modification/gun__adsSpeedMult;{value} to aiming speed
+modification/gun__recoilAmount;{value} to recoil impulse
+modification/gun__recoilDirAmount;{value} to recoil predictability
+modification/gun__recoilControlMult;{value} to recoil control
+modification/weap__sprintLerpFactor;{value} to speed up running
+armor_parameters/composition;Armor Composition and Parameters
+armor_parameters/weight;Armor Weight
+armorSegment/helmet/name;Helmet
+armorSegment/body/name;Torso Protection
+armorSegment/rear_plate/name;Rear Plate
+armorSegment/front_plate/name;Front Plate
+armorSegment/side_plate_L/name;Left Side Plate
+armorSegment/side_plate_R/name;Right Side Plate
+armorSegment/groin/name;Groin Protection
+armorSegment/groin_plate/name;Groin Protection Plate
+armorSegment/vest/name;Vest
+armorSegment/neck/name;Neck
+armorSegment/shoulder_L/name;Left Shoulder
+armorSegment/shoulder_R/name;Right Shoulder
+streaks/heroic_human;Marksman Elite
+streaks/heroic_human/other;
+streaks/heroic_human/desc;Destroyed the most enemy infantry.
+streaks/heroic_human_survivor;Predator
+streaks/heroic_human_survivor/other;
+streaks/heroic_human_survivor/desc;Hasn't lost a single infantry fireteam or a single vehicle (whether tank or aircraft) while destroying more enemy infantry than any other player on either team.
+streaks/heroic_human_punisher;Against All Odds
+streaks/heroic_human_punisher/other;
+streaks/heroic_human_punisher/desc;Destroyed the most enemy infantry that are by 1.0 battle rating higher than your own.
+streaks/trophy_near_human;Marksman
+streaks/trophy_near_human/other;
+streaks/trophy_near_human/desc;Destroyed the most enemy infantry. If several players have equal number of destroyed targets, the award is given to the one with a bigger score.
+streaks/human_bullseye;Bullseye: x%d
+streaks/human_bullseye/other;
+streaks/human_bullseye/desc;Reward for neutralizing enemy infantry from a long distance.
+streaks/human_bullseye/multiple;Bullseye
+streaks/human_row_melee_kill;Close and Personal: x%d
+streaks/human_row_melee_kill/multiple;Close and Personal
+streaks/human_row_melee_kill/other;
+streaks/human_row_melee_kill/desc;Reward for neutralizing 5 enemy infantrymen with melee weapons without losing your own fireteam.
+streaks/human_row_ai_members_kill;Commander: x%d
+streaks/human_row_ai_members_kill/multiple;Commander
+streaks/human_row_ai_members_kill/other;
+streaks/human_row_ai_members_kill/desc;Reward for neutralizing enemy infantry with AI-controlled soldiers of your fireteam without losing it.
+streaks/human_kill_entire_squad_rapid;Rapid Fire: x%d
+streaks/human_kill_entire_squad_rapid/multiple;Rapid Fire
+streaks/human_kill_entire_squad_rapid/other;
+streaks/human_kill_entire_squad_rapid/desc;Reward for quickly neutralizing an entire enemy fireteam using only your own fireteam.
+streaks/multi_kill_human;Multistrike x%d!
+streaks/multi_kill_human/other;
+streaks/multi_kill_human/desc;Neutralized %d infantrymen in a row.
+streaks/multi_kill_human/multiple/desc;Neutralized several infantrymen in a row.
+streaks/multi_kill_human/multiple;Multistrike!
+icon/mpstats/humanKills;╞
+icon/hud_msg_mp_dmg/kill_h_h;▒
+icon/hud_msg_mp_dmg/kill_t_h;▔
+icon/hud_msg_mp_dmg/kill_a_h;▦
+icon/hud_msg_mp_dmg/kill_h_a;▣
+icon/hud_msg_mp_dmg/kill_h_t;▣
+options/infantry_presets;Equipment Presets
+modGroup/scope;Scope
+modGroup/stock;Stock
+modGroup/magazine;Magazine
+modGroup/underbarrel;Underbarrel
+modGroup/tactical;Tactical
+modGroup/grip;Grip
+modGroup/muzzle;Muzzle
+unit/squadFeaturesHeader;Additional Equipment
+unit/bulletCaliber;Caliber
+unit/bulletSpeed;Bullet Velocity
+unit/bulletMass;Bullet Mass
+unit/bulletEnergy;Bullet Energy
+unit/bulletArmorPower;Armor Power
+unit/weaponShotFreq;Rate of Fire
+unit/weaponWeight;Weight (empty)
+unit/weaponRecoil;Recoil Impulse
+unit/weaponAmmoHolders;Ammunition
+location/hvg_granitograd;Granitograd
+location/hvg_training_ground;Training Ground
+missions/testRun;Test Mission
+missions/granitograd_infdom;Granitograd
+ak_12_shop;AK-12
+ak_12_0;AO Kontsern Kalashnikov | AK-12
+ak_12_1;AK-12
+ak_12_2;AK-12
+ak_15_shop;AO Kontsern Kalashnikov | AK-15
+ak_15_0;AK-15
+ak_15_1;AK-15
+ak_15_2;AK-15
+ak_74m_shop;AK-74M
+ak_74m_0;AO Kontsern Kalashnikov | AK-74M
+ak_74m_1;AK-74M
+ak_74m_2;AK-74M
+akm_47_shop;AKM
+akm_47_0;Izhévsky mashinostroítelny Zavod (IZhMASh) | AKM
+akm_47_1;AKM
+akm_47_2;AKM
+aksu_74_shop;AKS-74U
+aksu_74_0;AKS-74U
+aksu_74_1;AKS-74U
+aksu_74_2;Assault rifle
+asm_val_shop;ASM Val
+asm_val_0;ASM Val
+asm_val_1;AS Val
+asm_val_2;Assault rifle
+colt_9_mm_smg_shop;Colt 9mm SMG
+colt_9_mm_smg_0;Colt 9mm SMG
+colt_9_mm_smg_1;Colt 9mm
+colt_9_mm_smg_2;SMG
+kord_6p68_shop;Kord 6P68
+kord_6p68_0;Kord 6P68
+kord_6p68_1;6P68
+kord_6p68_2;Assault rifle
+m110a1_sdmr_shop;M110 SDMR
+m110a1_sdmr_0;M110 SDMR
+m110a1_sdmr_1;M110
+m110a1_sdmr_2;DMR
+m16a1_shop;M16A1
+m16a1_0;M16A1
+m16a1_1;M16
+m16a1_2;Assault rifle
+m16a4_shop;M16A4
+m16a4_0;M16A4
+m16a4_1;M16
+m16a4_2;Assault rifle
+m249_para_shop;M249 Para
+m249_para_0;M249 Para
+m249_para_1;Minimi
+m249_para_2;LMG
+m4a1_shop;M4A1
+m4a1_0;M4A1
+m4a1_1;M4
+m4a1_2;Assault rifle
+mac_11_shop;MAC-11 PDW
+mac_11_0;MAC-11 PDW
+mac_11_1;MAC-11
+mac_11_2;SMG
+mcmillan_tac_50_shop;TAC-50
+mcmillan_tac_50_0;TAC-50
+mcmillan_tac_50_1;TAC-50
+mcmillan_tac_50_2;AMR
+mk_14_ebr_shop;Mk 14 EBR
+mk_14_ebr_0;Mk 14 EBR
+mk_14_ebr_1;M14
+mk_14_ebr_2;BR
+mk_48_shop;Mk 48
+mk_48_0;Mk 48
+mk_48_1;Minimi
+mk_48_2;LMG
+pp_19_bizon_shop;PP-19
+pp_19_bizon_0;PP-19 Bizon
+pp_19_bizon_1;ПП-19
+pp_19_bizon_2;SMG
+pp_19_vityaz_shop;PP-19 Vityaz
+pp_19_vityaz_0;PP-19 Vityaz
+pp_19_vityaz_1;ПП-19
+pp_19_vityaz_2;SMG
+pp_2000_shop;PP-2000
+pp_2000_0;PP-2000
+pp_2000_1;PP-2000
+pp_2000_2;SMG
+rpk_16_shop;RPK-16
+rpk_16_0;RPK-16
+rpk_16_1;RPK
+rpk_16_2;LMG
+rpk_74m_shop;RPK-74M
+rpk_74m_0;RPK-74M
+rpk_74m_1;RPK
+rpk_74m_2;LMG
+sig_xm250_shop;M250
+sig_xm250_0;M250
+sig_xm250_1;M250
+sig_xm250_2;LMG
+sig_xm5_shop;XM5
+sig_xm5_0;XM5
+sig_xm5_1;XM5
+sig_xm5_2;BR
+svd_shop;SVD
+svd_0;SVD
+svd_1;SVD
+svd_2;DMR
+svd_m_shop;SVDM
+svd_m_0;SVDM
+svd_m_1;SVD
+svd_m_2;DMR
+vssm_vintorez_shop;VSSM Vintorez
+vssm_vintorez_0;VSSM Vintorez
+vssm_vintorez_1;VSS Vintorez
+vssm_vintorez_2;Assault rifle
+uav_inf_fpv_strike_drone_shop;"Strike UAV type ""FPV"""
+uav_inf_fpv_strike_drone_0;"Strike UAV type ""FPV"""
+uav_inf_fpv_strike_drone_1;"Strike UAV type ""FPV"""
+uav_inf_fpv_strike_drone_2;FPV
+uav_inf_strike_drone_shop;"Strike UAV type ""Wing"""
+uav_inf_strike_drone_0;"Strike UAV type ""Wing"""
+uav_inf_strike_drone_1;"Strike UAV type ""Wing"""
+uav_inf_strike_drone_2;WING
+uav_inf_recon_drone_shop;Reconnaissance UAV
+uav_inf_recon_drone_0;Reconnaissance UAV
+uav_inf_recon_drone_1;Reconnaissance UAV
+uav_inf_recon_drone_2;Scout
+infantry/squad/member;Soldier
+infantry/squad/member_inactive_advice;train your crew
+infantry/squad/member_inactive;Inactive
+infantry/squad/members;Soldiers
+weapons/infantry_empty;Empty
+weapons/ammo_box;Ammo box
+ammo_box;Ammo box
+weapons/ammo_box/desc;Allows all allies to refill ammo in battle. Ammo is limited.
+weapons/explosives_box_item;Explosives box
+explosives_box_item;Explosives box
+weapons/explosives_box_item/desc;Allows all allies to refill explosives in battle. Refills are limited.
+weapons/frag_grenade;Frag grenade
+frag_grenade;Frag grenade
+weapons/frag_grenade/desc;An explosive munition designed to destroy infantry.
+weapons/ks_p;18,5 KS-P shotgun
+ks_p;18,5 KS-P shotgun
+weapons/ks_p/desc;A shotgun is effective against drones. It is not recommended to use it against armored infantry.
+weapons/m136_at4;M136 AT4 anti-tank rocket launcher
+m136_at4;M136 AT4 anti-tank rocket launcher
+weapons/m136_at4/desc;A hand-held anti-tank rocket launcher for destroying armoured vehicles.
+weapons/medic_box;Medkits Box
+medic_box;Medkits Box
+weapons/medic_box/desc;Allows all allies to refill medkits in battle. Refills are limited.
+weapons/mossberg_590;Mossberg 590 shotgun
+mossberg_590;Mossberg 590 shotgun
+weapons/mossberg_590/desc;A shotgun is effective against drones. It is not recommended to use it against armored infantry.
+weapons/mpads_igla;9K38 Igla MANPADS
+mpads_igla;9K38 Igla MANPADS
+weapons/mpads_igla/desc;Man-portable air-defense systems for destroying low-flying air targets.
+weapons/mpads_stinger;FIM-92 Stinger MANPADS
+mpads_stinger;FIM-92 Stinger MANPADS
+weapons/mpads_stinger/desc;Man-portable air-defense systems for destroying low-flying air targets.
+weapons/pkp_pecheneg;PKP Pecheneg machine gun 
+pkp_pecheneg;PKP Pecheneg machine gun 
+weapons/pkp_pecheneg/desc;A general purpose machine gun for destroying infantry. It is recommended to use it after installing it on bipods.
+weapons/pslr_1_default;PSRL-1 rocket launcher
+pslr_1_default;PSRL-1 rocket launcher
+weapons/pslr_1_default/desc;A hand-held anti-tank grenade launcher for destroying armoured vehicles.
+weapons/reapr;REAPR machine gun 
+reapr;REAPR machine gun 
+weapons/reapr/desc;A machine gun for destroying infantry. It is recommended to use it after installing it on bipods.
+weapons/rpg_7;RPG-7 rocket launcher
+rpg_7;RPG-7 rocket launcher
+weapons/rpg_7/desc;A hand-held anti-tank rocket launcher for destroying armoured vehicles.
+weapons/rpg_7_default;RPG-7 rocket launcher
+rpg_7_default;RPG-7 rocket launcher
+weapons/rpg_7_default/desc;A hand-held anti-tank rocket launcher for destroying armoured vehicles.
+weapons/smoke_grenade;Smoke grenade
+smoke_grenade;Smoke grenade
+weapons/smoke_grenade/desc;A pyrotechnic device designed to create smoke zones for camouflage purposes.
+weapons/stun_grenade;Stun grenade
+stun_grenade;Stun grenade
+weapons/stun_grenade/desc;A non-lethal weapon designed to provide light and sound effects on an enemy to temporarily incapacitate them.
+weapons/usa_fpv_drone;FPV drone
+usa_fpv_drone;FPV drone
+weapons/usa_fpv_drone/desc;A quadcopter with an attached ammo from a hand-held anti-tank rocket launcher. Use against ground vehicles.
+weapons/usa_kamikaze_drone;Loitering munition
+usa_kamikaze_drone;Loitering munition
+weapons/usa_kamikaze_drone/desc;An unmanned aerial vehicle with a warhead. Use against ground vehicles.
+weapons/usa_recon_drone;Reconnaissance drone
+usa_recon_drone;Reconnaissance drone
+weapons/usa_recon_drone/desc;A quadcopter with software for automatic enemy recognition.
+weapons/ussr_fpv_drone;FPV drone
+ussr_fpv_drone;FPV drone
+weapons/ussr_fpv_drone/desc;A quadcopter with an attached ammo from a hand-held anti-tank rocket launcher. Use against ground vehicles.
+weapons/ussr_kamikaze_drone;Loitering munition
+ussr_kamikaze_drone;Loitering munition
+weapons/ussr_kamikaze_drone/desc;An unmanned aerial vehicle with a warhead. Use against ground vehicles.
+weapons/ussr_recon_drone;Reconnaissance drone
+ussr_recon_drone;Reconnaissance drone
+weapons/ussr_recon_drone/desc;A quadcopter with software for automatic enemy recognition.
+userlog/human_player_offender;player
+userlog/human_squad_member_offender;fireteam member
+skin_infantry/random_not_default/name;Random not default
+options/infantry_skin;Camouflage
+skin_infantry/granit_team1_highbr_camo1/name;Camouflage 2
+skin_infantry/granit_team1_lowbr_camo1/name;Camouflage 1
+skin_infantry/granit_team2_highbr_camo1/name;Camouflage 2
+skin_infantry/granit_team2_lowbr_camo1/name;Camouflage 1
+45acp_m1911_fmj;.45 ACP M1911
+45acp_m26_fmj_t;.45 ACP M26
+45acp_jhp;.45 АСР P+ JHP
+12_7mm_sn;12.7 mm 7N34
+12_7mm_b32;12.7 mm B-32
+12_7mm_bs41;12.7mm BS-41
+12_7mm_m20;.50 M20 API
+14_5mm_bs41;14.5 mm BS-41
+7_62mm_m2_ball;.30-06 М2
+7_62mm_ap;.30-06 AP
+7_62mm_tracer;.30-06 T
+4_6mm_ap_sx;4.6 mm AP SX
+5_45mm_7n24_ap;5.45 mm 7N24
+5_45mm_7n39_ap;5.45 mm 7N39
+5_45mm_7n6_gp;5.45 mm 7N6
+5_45mm_7n6m_ep;5.45 mm 7N6M
+5_45mm_7n10_ep;5.45 mm 7N10
+5_45mm_7n22_ep;5.45 mm 7N22
+5_45mm_7t3_tracer;5.45 mm 7T3
+5_56mm_m995_ap;5.56 mm M995
+5_56mm_m193_ball;5.56 mm M193
+5_56mm_m196_tracer;5.56 mm M196
+5_56mm_m855_ep;5.56 mm M855
+5_56mm_m855a1_ep;5.56 mm M855A1
+5_56mm_m856_tracer;5.56 mm M856
+5_8mm_dbp_87_gp;5.8 mm DBP-87
+6_8mm_m1186_gp;6.8 mm M1186
+6_8mm_m1184_ap;6.8 mm M1184
+6_8mm_m1187_t;6.8 mm M1187
+7_62mm_tt;7.62 mm 57-N-134
+7_62mm_57n134s;7.62 mm 57-N-134S
+7_62mm_bz_ap;7.62 mm 57-BZ-231
+7_62mm_m1943_gp;7.62 mm M43
+7_62mm_57n231_gp;7.62 mm 57-N-231
+7_62mm_57n231_ep;7.62 mm 57-N-231M
+7_62mm_7n23_ap;7.62 mm 7N23
+7_62mm_57t231_tracer;7.62 mm 57-T-231
+7_62mm_m993_ap;7.62 mm M993
+7_62mm_m118_ball;7.62 mm M118
+7_62mm_m80_ball;7.62 mm M80
+7_62mm_m59_ball;7.62 mm M59
+7_62mm_m61_ap;7.62 mm M61
+7_62mm_m62_tracer;7.62 mm M62
+7_62mm_57n223s_gp;7.62 mm LPS
+7_62mm_57n223s_st_m2_ep;7.62 mm ST-M2
+7_62mm_57n223_gp;7.62 mm L
+7_62mm_57b222;7.62 mm B-30
+7_62mm_57bz322;7.62 mm B-32
+7_62mm_57bzt322;7.62 mm BZT
+7_62mm_bs_40;7.62 mm BS-40
+7_62mm_7n1;7.62 mm 7N1
+7_62mm_7n13_ap;7.62 mm 7N13
+7_62mm_7n14_ap;7.62 mm 7N14
+7_62mm_7n26_ap;7.62 mm 7N26
+7_62mm_7n37_hc;7.62 mm 7N37
+7_62mm_7bt1_tracer;7.62 mm 7BT1
+7_62mm_7t2_tracer;7.62 mm 7T2
+7_62mm_t_30;7.62 mm 57-T-322
+7_62mm_t_46;7.62 mm 57-T-322
+9mm_57n181_fmj;9 mm 57-N-181
+9mm_57n181s_sc;9 mm 57-N-181S
+9mm_57t181_sc_t;9 mm 57-T-181
+9mm_7n16_ap;9 mm 7N16
+9mm_7n25_ap;9 mm 7N25
+9mm_ppe_jhp;9 mm PPE
+9mm_7n31_ap;9 mm 7N31
+9mm_7n21_ap;9 mm 7N21
+9mm_m882_fmj;9 mm M882
+9mm_m1152_fmj;9 mm M1152
+9mm_m1153_jhp;9 mm M1153SP
+9mm_ppatr08;9 mm Patr. 08
+9mm_sp10_ap;9 mm SP-10
+9mm_sp11_ball;9 mm 7N28
+9mm_sp12_hp;9 mm SP-12
+9mm_sp13_ap;9 mm SP-13
+9mm_sp5_ball;9 mm SP-5
+9mm_sp6_ap;9 mm SP-6
+9mm_pab_9_ap;9 mm PAB-9
+9mm_bp_ap;9 mm BP
+9mm_spp_ap;9 mm SPP
+su_9M39;9M39 Igla SAM
+rpg_2_rocket;RPG-2
+93mm_pg_7vl;RPG-7
+84mm_at4;AT4

--- a/Mod Files/syrup_units_cn.csv
+++ b/Mod Files/syrup_units_cn.csv
@@ -370,7 +370,7 @@
 "f_16a_block_20_mlu_2";"☀F-16A-20";;
 #
 "j_10a_shop";"J-10A Měnglóng";;
-"j_10a_0";"Chengdu Aircraft Corporation (CAC) | J-10A Měnglóng (Vigorous Dragon)";;
+"j_10a_0";"Chengdu Aircraft Corporation (CAC) | J-10A Měnglóng (Vigorous Dragon) / Firebird";;
 "j_10a_1";"J-10A Měnglóng";;
 "j_10a_2";"J-10A";;
 #
@@ -379,23 +379,23 @@
 "mirage_2000_5ei_1";"☀Mirage 2000-5Ei";;
 "mirage_2000_5ei_2";"☀Mirage 2000-5Ei";;
 #
-"j_11_shop";"␗J-11 Flanker-B+";;
-"j_11_0";"Shenyang Aircraft Corporation | ␗J-11 Flanker-B+ | Su-27SK (2000)";;
-"j_11_1";"␗J-11 Flanker-B+";;
+"j_11_shop";"␗J-11 Yìnglóng";;
+"j_11_0";"Shenyang Aircraft Corporation | ␗J-11 Yìnglóng (Responsive Dragon) | Su-27SK Flanker-B+ (2000)";;
+"j_11_1";"␗J-11 Yìnglóng";;
 "j_11_2";"␗J-11";;
 #
-"j_11a_shop";"␗J-11A MLU Flanker-B+";;
-"j_11a_0";"Shenyang Aircraft Corporation | ␗J-11A Flanker-B+ | Su-27SK | Mid-Life Update (2015)";;
-"j_11a_1";"␗J-11A MLU Flanker-B+";;
+"j_11a_shop";"␗J-11A MLU Yìnglóng";;
+"j_11a_0";"Shenyang Aircraft Corporation | ␗J-11A Yìnglóng (Responsive Dragon) | Su-27SK Flanker-B+ | Mid-Life Update (2015)";;
+"j_11a_1";"␗J-11A MLU Yìnglóng";;
 "j_11a_2";"␗J-11A MLU";;
 #
-"j_11b_shop";"␗J-11B Flanker-L";;
-"j_11b_0";"Shenyang Aircraft Corporation | ␗J-11B Flanker-L";;
-"j_11b_1";"␗J-11B Flanker-L";;
+"j_11b_shop";"␗J-11B Yìnglóng";;
+"j_11b_0";"Shenyang Aircraft Corporation | ␗J-11B Yìnglóng (Responsive Dragon) / Flanker-L";;
+"j_11b_1";"J-11B Yìnglóng";;
 "j_11b_2";"␗J-11B";;
 #
 "jh_7a_shop";"JH-7A Fēi Bào";;
-"jh_7a_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard)";;
+"jh_7a_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard) / Flounder";;
 "jh_7a_1";"JH-7A Fēi Bào";;
 "jh_7a_2";"JH-7A";;
 #
@@ -405,17 +405,17 @@
 "jf_17_2";"JF-17A";;
 #
 "jh_7_shop";"JH-7 Fēi Bào";;
-"jh_7_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7 Fēi Bào (Flying Leopard) | Block 02";;
+"jh_7_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7 Fēi Bào (Flying Leopard) / Flounder | Block 02";;
 "jh_7_1";"JH-7 Fēi Bào";;
 "jh_7_2";"JH-7";;
 #
 "jh_7a_prototype_shop";"JH-7A Fēi Bào (811)";;
-"jh_7a_prototype_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard) | Prototype 811";;
+"jh_7a_prototype_0";"Xi'an Aircraft Industrial Corporation (XAC) | JH-7A Fēi Bào (Flying Leopard) / Flounder | Prototype 811 -- on statcard";;
 "jh_7a_prototype_1";"JH-7A Fēi Bào (811)";;
 "jh_7a_prototype_2";"JH-7A (811)";;
 #
 j_10c_shop;J-10C Měnglóng;;
-j_10c_0;Chengdu Aircraft Corporation (CAC) | J-10C Měnglóng (Vigorous Dragon);;
+j_10c_0;Chengdu Aircraft Corporation (CAC) | J-10C Měnglóng (Vigorous Dragon) / Firebird;;
 j_10c_1;J-10C Měnglóng;;
 j_10c_2;J-10C;;
 #

--- a/Mod Files/syrup_units_gb.csv
+++ b/Mod Files/syrup_units_gb.csv
@@ -696,7 +696,7 @@ f_111c_raaf_1;▄F-111C Aardvark (1986);;
 f_111c_raaf_2;▄F-111C (1986);;
 #
 ef_2000_typhoon_aesa_shop;▄Typhoon FGR.4 (ZK355);;
-ef_2000_typhoon_aesa_0;Eurofighter Jagdflugzeug GmbH | ▄Typhoon | Fighter/Ground Attack/Reconnaissance, Mk.4 | ZK355 Testbed (2019);;
+ef_2000_typhoon_aesa_0;Eurofighter Jagdflugzeug GmbH | ▄Typhoon | Fighter/Ground Attack/Reconnaissance, Mk.4 | ZK355 Testbed (2024);;
 ef_2000_typhoon_aesa_1;▄Typhoon FGR.4 (ZK355);;
 ef_2000_typhoon_aesa_2;▄Typhoon FGR.4 (ZK355);;
 #

--- a/Mod Files/syrup_units_ger.csv
+++ b/Mod Files/syrup_units_ger.csv
@@ -398,7 +398,7 @@ tornado_ids_de_assta1_killstreak_2;☢IDS-Tornado (ASSTA 1.0);;
 "mig_29_9_12g_shop";"◄MiG-29G Fulcrum-A";;
 "mig_29_9_12g_0";"◄OKB-155 ""Mikoyan"" | MiG-29G Fulcrum-A | Izdeliye 9-12A";;
 "mig_29_9_12g_1";"◄MiG-29G Fulcrum-A";;
-"mig_29_9_12g_2";"◄MiG-29A";;
+"mig_29_9_12g_2";"◄MiG-29G";;
 #
 "hunter_f58a_1971_switzerland_shop";"◌Hunter Mk.58A (1971)";;
 "hunter_f58a_1971_switzerland_0";"◌Hawker Aircraft, Ltd. | Hunter Mk.58A (1971)";;

--- a/Mod Files/syrup_units_jp.csv
+++ b/Mod Files/syrup_units_jp.csv
@@ -510,20 +510,20 @@
 "p-51c-11-nt_japan_1";"▅P-51C-11 Mustang";;
 "p-51c-11-nt_japan_2";"▅P-51C-11";;
 #
-"sb2c_5_thailand_shop";"▄B.J.3 Helldiver";;
-"sb2c_5_thailand_0";"Curtiss-Wright Corporation | ▄B.J.3 | SB2C-5 Helldiver";;
-"sb2c_5_thailand_1";"▄B.J.3 Helldiver";;
-"sb2c_5_thailand_2";"▄B.J.3";;
+"sb2c_5_thailand_shop";"▄SB2C-5 Helldiver";;
+"sb2c_5_thailand_0";"Curtiss-Wright Corporation | ▄SB2C-5 Helldiver / B.J.3";;
+"sb2c_5_thailand_1";"▄SB2C-5 Helldiver";;
+"sb2c_5_thailand_2";"▄SB2C-5";;
 #
 "b-17e_japan_shop";"▅B-17E Flying Fortress";;
 "b-17e_japan_0";"▅Boeing Airplane Company | B-17E Flying Fortress";;
 "b-17e_japan_1";"▅B-17E Flying Fortress";;
 "b-17e_japan_2";"▅B-17E";;
 #
-"f-84g_thailand_shop";"▄B.Kh.16 Thunderjet";;
-"f-84g_thailand_0";"Republic Aviation Corporation | ▄B.Kh.16 | F-84G-21 Thunderjet";;
-"f-84g_thailand_1";"▄B.Kh.16 Thunderjet";;
-"f-84g_thailand_2";"▄B.Kh.16";;
+"f-84g_thailand_shop";"▄F-84G-21 Thunderjet";;
+"f-84g_thailand_0";"Republic Aviation Corporation | ▄F-84G-21 Thunderjet / B.Kh.16";;
+"f-84g_thailand_1";"▄F-84G-21 Thunderjet";;
+"f-84g_thailand_2";"▄F-84G-21";;
 #
 "f-86f-30_japan_shop";"▅F-86F-30 Sabre";;
 "f-86f-30_japan_0";"North American Aviation | ▅F-86F-30 Sabre | Block 30";;
@@ -540,20 +540,20 @@
 "f-86f-40_japan_blue_impulse_1";"▅F-86F-40 Sabre (6 SQN)";;
 "f-86f-40_japan_blue_impulse_2";"▅F-86F-40 (6 SQN)";;
 #
-"alpha_jet_a_thailand_shop";"▄B.J.7 Alpha Jet (1999)";;
-"alpha_jet_a_thailand_0";"Dassault/Dornier | ▄B.J.7 | Alpha Jet A (1999)";;
-"alpha_jet_a_thailand_1";"▄B.J.7 Alpha Jet (1999)";;
-"alpha_jet_a_thailand_2";"▄B.J.7 (1999)";;
+"alpha_jet_a_thailand_shop";"▄Alpha Jet A (1999)";;
+"alpha_jet_a_thailand_0";"Dassault/Dornier | ▄Alpha Jet A / B.J.7 (1999)";;
+"alpha_jet_a_thailand_1";"▄Alpha Jet A (1999)";;
+"alpha_jet_a_thailand_2";"▄Alpha Jet A (1999)";;
 #
-"alpha_jet_th_phase_1_shop";"▄B.J.7 Alpha Jet (2004)";;
-"alpha_jet_th_phase_1_0";"Dassault/Dornier | ▄B.J.7 | Alpha Jet TH, Phase 1 (2004)";;
-"alpha_jet_th_phase_1_1";"▄B.J.7 Alpha Jet (2004)";;
-"alpha_jet_th_phase_1_2";"▄B.J.7 (2004)";;
+"alpha_jet_th_phase_1_shop";"▄Alpha Jet TH";;
+"alpha_jet_th_phase_1_0";"Dassault/Dornier | ▄Alpha Jet TH / B.J.7 | Phase 1 (2004)";;
+"alpha_jet_th_phase_1_1";"▄Alpha Jet TH";;
+"alpha_jet_th_phase_1_2";"▄Alpha Jet TH";;
 #
-"av_8s_thailand_shop";"▄B.KhL.1 Matador (1973)";;
-"av_8s_thailand_0";"Hawker Siddeley Group, Ltd. | ▄B.KhL.1 | AV-8S Matador (1973)";;
-"av_8s_thailand_1";"▄B.KhL.1 Matador (1973)";;
-"av_8s_thailand_2";"▄B.KhL.1 (1973)";;
+"av_8s_thailand_shop";"▄AV-8S Matador (1973)";;
+"av_8s_thailand_0";"Hawker Siddeley Group, Ltd. | ▄AV-8S Matador / B.KhL.1 (1973)";;
+"av_8s_thailand_1";"▄AV-8S Matador (1973)";;
+"av_8s_thailand_2";"▄AV-8S (1973)";;
 #
 "t2_early_shop";"T-2 (1975)";;
 "t2_early_0";"Mitsubishi Heavy Industries, Ltd. | T-2 | Zenki-gata (1975)";;
@@ -575,30 +575,30 @@
 "f-104j_1";"▅F-104J Starfighter";;
 "f-104j_2";"▅F-104J";;
 #
-"a_7e_thailand_shop";"▄B.HT.1 Corsair II";;
-"a_7e_thailand_0";"LTV Aerospace Corporation | ▄B.HT.1 | A-7E Corsair II";;
-"a_7e_thailand_1";"▄B.HT.1 Corsair II";;
-"a_7e_thailand_2";"▄B.HT.1";;
+"a_7e_thailand_shop";"▄A-7E Corsair II";;
+"a_7e_thailand_0";"LTV Aerospace Corporation | ▄A-7E Corsair II / B.HT.1";;
+"a_7e_thailand_1";"▄A-7E Corsair II";;
+"a_7e_thailand_2";"▄A-7E";;
 #
-"f-5a_thailand_shop";"▄B.Kh.18 Freedom Fighter";;
-"f-5a_thailand_0";"Northrop Corporation | ▄B.Kh.18 | F-5A Freedom Fighter";;
-"f-5a_thailand_1";"▄B.Kh.18 Freedom Fighter";;
-"f-5a_thailand_2";"▄B.Kh.18";;
+"f-5a_thailand_shop";"▄F-5A Freedom Fighter";;
+"f-5a_thailand_0";"Northrop Corporation  | ▄F-5A Freedom Fighter / B.Kh.18";;
+"f-5a_thailand_1";"▄F-5A Freedom Fighter";;
+"f-5a_thailand_2";"▄F-5A";;
 #
-"f-5e_fcu_thailand_shop";"▄B.Kh.18Kh Tigris (1988)";;
-"f-5e_fcu_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5T Tigris | First Capability Upgrade (1988)";;
-"f-5e_fcu_thailand_1";"▄B.Kh.18Kh Tigris (1988)";;
-"f-5e_fcu_thailand_2";"▄B.Kh.18Kh (1988)";;
+"f-5e_fcu_thailand_shop";"▄F-5T Tigris (1988)";;
+"f-5e_fcu_thailand_0";"Northrop Corporation  | ▄F-5T Tigris / B.Kh.18Kh | First Capability Upgrade (1988)";;
+"f-5e_fcu_thailand_1";"▄F-5T Tigris (1988)";;
+"f-5e_fcu_thailand_2";"▄F-5T (1988)";;
 #
-"f-5t_thailand_shop";"▄B.Kh.18Kh Tigris (2003)";;
-"f-5t_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5T Tigris | Second Capability Upgrade (2003)";;
-"f-5t_thailand_1";"▄B.Kh.18Kh Tigris (2003)";;
-"f-5t_thailand_2";"▄B.Kh.18Kh (2003)";;
+"f-5t_thailand_shop";"▄F-5T Tigris (2003)";;
+"f-5t_thailand_0";"Northrop Corporation | ▄F-5T Tigris / B.Kh.18Kh | Second Capability Upgrade (2003)";;
+"f-5t_thailand_1";"▄F-5T Tigris (2003)";;
+"f-5t_thailand_2";"▄F-5T (2003)";;
 #
-"av_8s_late_thailand_shop";"▄B.KhL.1 Matador (1998)";;
-"av_8s_late_thailand_0";"Hawker Siddeley Group, Ltd. | ▄B.KhL.1 | AV-8S Matador (1998)";;
-"av_8s_late_thailand_1";"▄B.KhL.1 Matador (1998)";;
-"av_8s_late_thailand_2";"▄B.KhL.1 (1998)";;
+"av_8s_late_thailand_shop";"▄AV-8S Matador (1998)";;
+"av_8s_late_thailand_0";"Hawker Siddeley Group, Ltd. | ▄AV-8S Matador / B.KhL.1 (1998)";;
+"av_8s_late_thailand_1";"▄AV-8S Matador (1998)";;
+"av_8s_late_thailand_2";"▄AV-8S (1998)";;
 #
 "f-4ej_shop";"▅F-4EJ Phantom II";;
 "f-4ej_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-4EJ Phantom II";;
@@ -610,15 +610,15 @@
 "f-4ej_adtw_1";"▅F-4EJ Phantom II (ADTW)";;
 "f-4ej_adtw_2";"▅F-4EJ (ADTW)";;
 #
-"f_16a_block_15_ocu_thailand_shop";"▄B.Kh.19 Viper";;
-"f_16a_block_15_ocu_thailand_0";"General Dynamics Corporation | ▄B.Kh.19 | F-16A-15OCU Viper | Mid-Life Update (2010)";;
-"f_16a_block_15_ocu_thailand_1";"▄B.Kh.19 Viper";;
-"f_16a_block_15_ocu_thailand_2";"▄B.Kh.19";;
+"f_16a_block_15_ocu_thailand_shop";"▄F-16A-15OCU Viper (2010)";;
+"f_16a_block_15_ocu_thailand_0";"General Dynamics Corporation | ▄F-16A-15OCU Viper / B.Kh.19 | Mid-Life Update (2010)";;
+"f_16a_block_15_ocu_thailand_1";"▄F-16A-15OCU Viper (2010)";;
+"f_16a_block_15_ocu_thailand_2";"▄F-16A-15OCU (2010)";;
 #
-"saab_jas39c_thailand_shop";"▄B.Kh.20 Gripen C";;
-"saab_jas39c_thailand_0";"Saab AB | ▄B.Kh.20 | JAS 39C Gripen";;
-"saab_jas39c_thailand_1";"▄B.Kh.20 Gripen C";;
-"saab_jas39c_thailand_2";"▄B.Kh.20";;
+"saab_jas39c_thailand_shop";"▄JAS 39C Gripen";;
+"saab_jas39c_thailand_0";"Saab AB | ▄JAS 39C Gripen / B.Kh.20";;
+"saab_jas39c_thailand_1";"▄JAS 39C Gripen";;
+"saab_jas39c_thailand_2";"▄JAS 39C";;
 #
 "f-4ej_kai_shop";"▅F-4EJ Kai Phantom II";;
 "f-4ej_kai_0";"Mitsubishi Heavy Industries, Ltd. | ▅F-4EJ Kai Phantom II";;
@@ -650,10 +650,10 @@
 "f_2a_adtw_1";"XF-2A Viper Zero";;
 "f_2a_adtw_2";"XF-2A";;
 #
-"f-5th_thailand_shop";"▄B.Kh.18Kh Super Tigris (2014)";;
-"f-5th_thailand_0";"Northrop Corporation | ▄B.Kh.18Kh | F-5TH Super Tigris | Third Capability Upgrade (2014)";;
-"f-5th_thailand_1";"▄B.Kh.18Kh Super Tigris (2014)";;
-"f-5th_thailand_2";"▄B.Kh.18Kh (2014)";;
+"f-5th_thailand_shop";"▄F-5TH Super Tigris";;
+"f-5th_thailand_0";"Northrop Corporation | ▄F-5TH Super Tigris / B.Kh.18Kh | Third Capability Upgrade (2014)";;
+"f-5th_thailand_1";"▄F-5TH Super Tigris";;
+"f-5th_thailand_2";"▄F-5TH";;
 #
 fa_18d_late_malaysia_shop;▄F/A-18D-52 Hornet;;
 fa_18d_late_malaysia_0;McDonnell Douglas Corporation | ▄F/A-18D-52 Hornet | Block 52, Lot 20 (1992);;

--- a/Mod Files/syrup_units_usa.csv
+++ b/Mod Files/syrup_units_usa.csv
@@ -597,7 +597,7 @@
 "f-86f-25_2";"F-86F-25";;
 #
 "f2h-2_shop";"F2H-2 Banshee";;
-"f2h-2_0";"McDonnell F2H-2 Banshee";;
+"f2h-2_0";"McDonnell Aircraft Corporation | F2H-2 Banshee";;
 "f2h-2_1";"F2H-2 Banshee";;
 "f2h-2_2";"F2H-2";;
 #
@@ -816,20 +816,20 @@ f_111f_killstreak_2;☢F-111F;;
 "a_7k_1";"A-7K Corsair II";;
 "a_7k_2";"A-7K";;
 #
-"a_6e_tram_shop";"A-6E TRAM Intruder";;
-"a_6e_tram_0";"Grumman Aerospace Corporation | A-6E TRAM Intruder";;
-"a_6e_tram_1";"A-6E TRAM Intruder";;
-"a_6e_tram_2";"A-6E TRAM";;
+"a_6e_tram_shop";"A-6E Intruder (TRAM)";;
+"a_6e_tram_0";"Grumman Aerospace Corporation | A-6E Intruder | Target Recognition and Attack Multi-Sensor System (1979)";;
+"a_6e_tram_1";"A-6E Intruder (TRAM)";;
+"a_6e_tram_2";"A-6E (TRAM)";;
 #
 "av_8b_na_shop";"AV-8B Harrier II (NA)";;
 "av_8b_na_0";"McDonnell Douglas Corporation | AV-8B Harrier II | Night Attack";;
 "av_8b_na_1";"AV-8B Harrier II (NA)";;
 "av_8b_na_2";"AV-8B (NA)";;
 #
-"f_15c_msip2_shop";"F-15C-40 MSIP II Eagle";;
+"f_15c_msip2_shop";"F-15C-40 Eagle (MSIP II)";;
 "f_15c_msip2_0";"Boeing Defense, Space & Security | F-15C-40 Eagle | Block 40 | Multi-Stage Improvement Program Configuration II (2000)";;
-"f_15c_msip2_1";"F-15C-40 MSIP II Eagle";;
-"f_15c_msip2_2";"F-15C-40";;
+"f_15c_msip2_1";"F-15C-40 Eagle (MSIP II)";;
+"f_15c_msip2_2";"F-15C-40 (MSIP II)";;
 #
 "f_15e_shop";"F-15E-43 Strike Eagle";;
 "f_15e_0";"McDonnell Douglas Corporation | F-15E-43 Strike Eagle | Block 43";;
@@ -886,10 +886,10 @@ f_111f_killstreak_2;☢F-111F;;
 "f_14b_1";"F-14B-150 Tomcat";;
 "f_14b_2";"F-14B-150";;
 #
-"f_15a_shop";"F-15A-20 MSIP I Eagle";;
+"f_15a_shop";"F-15A-20 Eagle (MSIP I)";;
 "f_15a_0";"McDonnell Douglas Corporation | F-15A-20 Eagle | Block 20 | Multi-Stage Improvement Program Configuration I (1983)";;
-"f_15a_1";"F-15A-20 MSIP I Eagle";;
-"f_15a_2";"F-15A-20 MSIP I";;
+"f_15a_1";"F-15A-20 Eagle (MSIP I)";;
+"f_15a_2";"F-15A-20 (MSIP I)";;
 #
 "av_8b_plus_shop";"AV-8B+ Harrier II";;
 "av_8b_plus_0";"McDonnell Douglas Corporation | AV-8B+ Harrier II";;
@@ -931,15 +931,15 @@ f_111f_killstreak_2;☢F-111F;;
 "p-40c_1";"P-40C Warhawk";;
 "p-40c_2";"P-40C";;
 #
-"f_106a_1972_shop";"F-106A-100 Delta Dart (1975)";;
+"f_106a_1972_shop";"F-106A-100 Delta Dart";;
 "f_106a_1972_0";"General Dynamics Convair Division | F-106A-100 Delta Dart | Block 100 | Project Six Shooter | Polhemus Director FCS Integration and Test (1975)";;
-"f_106a_1972_1";"F-106A-100 Delta Dart (1975)";;
-"f_106a_1972_2";"F-106A-100 (1975)";;
+"f_106a_1972_1";"F-106A-100 Delta Dart";;
+"f_106a_1972_2";"F-106A-100";;
 #
-"f_15c_golden_eagle_shop";"F-15C-33 RIP/PASS Golden Eagle";;
-"f_15c_golden_eagle_0";"Boeing Defense, Space & Security | F-15C-33 Golden Eagle | Radar Improvement Program | Passive Attack Sensor System";;
-"f_15c_golden_eagle_1";"F-15C-33 RIP/PASS Golden Eagle";;
-"f_15c_golden_eagle_2";"F-15C-33 RIP/PASS";;
+"f_15c_golden_eagle_shop";"F-15C-33 Golden Eagle (RIP/PASS)";;
+"f_15c_golden_eagle_0";"Boeing Defense, Space & Security | F-15C-33 Golden Eagle | Block 33 | Radar Improvement Program | Passive Attack Sensor System";;
+"f_15c_golden_eagle_1";"F-15C-33 Golden Eagle (RIP/PASS)";;
+"f_15c_golden_eagle_2";"F-15C-33 (RIP/PASS)";;
 #
 "xf5u_1_shop";"XF5U-1 Flying Flapjack";;
 "xf5u_1_0";"Vought-Sikorsky Aircraft | XF5U-1 Flying Flapjack";;

--- a/Mod Files/syrup_units_ussr.csv
+++ b/Mod Files/syrup_units_ussr.csv
@@ -1,900 +1,900 @@
-"<ID|readonly|noverify>";"<English>";;;
-#
-"itp_m1_shop";"ITP (M-1)";;;
-"itp_m1_0";"N. Polikarpov OKB | Istrebitel Tyazholiy Pushechniy (ITP) | M-1 Prototype, 1942";;;
-"itp_m1_1";"ITP (M-1)";;;
-"itp_m1_2";"ITP (M-1)";;;
-#
-"tis_ma_shop";"TIS (MA)";;;
-"tis_ma_0";"N. Polikarpov OKB | Tyazholyy Istrebitel' Soprovozhdeniya (TIS) | MA Prototype, 1941";;;
-"tis_ma_1";"TIS (MA)";;;
-"tis_ma_2";"TIS (MA)";;;
-#
-"il_8_1944_shop";"Il-8 Sturmovik (1944)";;;
-"il_8_1944_0";"OKB-39 ""Ilyushin"" | Il-8 Sturmovik | Obrazets 1944";;;
-"il_8_1944_1";"Il-8 Sturmovik (1944)";;;
-"il_8_1944_2";"Il-8 (1944)";;;
-#
-"yak-3_eremin_shop";"Yak-3  (1944) [Eremin]";;;
-"yak-3_eremin_0";"OKB-115 ""Yakovlev"" | Eremin's Yak-3 | Obrazets 1944";;;
-"yak-3_eremin_1";"Yak-3  (1944) [Eremin]";;;
-"yak-3_eremin_2";"Yak-3 (1944) [Eremin]";;;
-#
-"b_25j_30_vvs_ussr_shop";"▂B-25J-30 Mitchell";;;
-"b_25j_30_vvs_ussr_0";"▂North American Aviation | B-25J-30 Mitchell | Block 30";;;
-"b_25j_30_vvs_ussr_1";"▂B-25J-30 Mitchell";;;
-"b_25j_30_vvs_ussr_2";"▂B-25J-30";;;
-#
-"p-47d_ussr_shop";"▂P-47D-27 Thunderbolt";;;
-"p-47d_ussr_0";"▂Republic Aviation Corporation | P-47D-27 Thunderbolt | Block 27";;;
-"p-47d_ussr_1";"▂P-47D-27 Thunderbolt";;;
-"p-47d_ussr_2";"▂P-47D-27";;;
-#
-"p-63a-5_ussr_shop";"▂P-63A-5 Kingcobra";;;
-"p-63a-5_ussr_0";"▂Bell Aircraft Corporation | P-63A-5 Kingcobra | Block 5";;;
-"p-63a-5_ussr_1";"▂P-63A-5 Kingcobra";;;
-"p-63a-5_ussr_2";"▂P-63A-5";;;
-#
-"p-63c-5_ussr_shop";"▂P-63C-5 Kingcobra";;;
-"p-63c-5_ussr_0";"▂Bell Aircraft Corporation | P-63C-5 Kingcobra | Block 5";;;
-"p-63c-5_ussr_1";"▂P-63C-5 Kingcobra";;;
-"p-63c-5_ussr_2";"▂P-63C-5";;;
-#
-"a_20g_30_ussr_shop";"▂A-20G-30 Havoc";;;
-"a_20g_30_ussr_0";"▂Douglas Aircraft Company | A-20G-30 Havoc | Block 30";;;
-"a_20g_30_ussr_1";"▂A-20G-30 Havoc";;;
-"a_20g_30_ussr_2";"▂A-20G-30";;;
-#
-"i_185_m71_standard_shop";"I-185/M-71";;;
-"i_185_m71_standard_0";"N. Polikarpov OKB | I-185 | Obrazets 1942, M-71 Engine";;;
-"i_185_m71_standard_1";"I-185/M-71";;;
-"i_185_m71_standard_2";"I-185/M-71";;;
-#
-"i_185_m82_shop";"I-185/M-82";;;
-"i_185_m82_0";"N. Polikarpov OKB | I-185 | 1940 Prototype, M-82 Engine";;;
-"i_185_m82_1";"I-185/M-82";;;
-"i_185_m82_2";"I-185/M-82";;;
-#
-"la-5fn_shop";"La-5FN";;;
-"la-5fn_0";"OKB-301 ""Lavochkin"" | La-5FN";;;
-"la-5fn_1";"La-5FN";;;
-"la-5fn_2";"La-5FN";;;
-#
-"il_2m_1943_shop";"Il-2M Sturmovik (1943)";;;
-"il_2m_1943_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik | Obrazets 1943";;;
-"il_2m_1943_1";"Il-2M Sturmovik (1943)";;;
-"il_2m_1943_2";"Il-2M (1943)";;;
-#
-"il-2m_mstitel_shop";"Il-2M Sturmovik ""Mstitel""";;;
-"il-2m_mstitel_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik ""Мstitel""";;;
-"il-2m_mstitel_1";"Il-2M Sturmovik ""Mstitel""";;;
-"il-2m_mstitel_2";"Il-2M ""Мstitel""";;;
-#
-"il-2m_shop";"Il-2M3 Sturmovik";;;
-"il-2m_0";"OKB-39 ""Ilyushin"" | Il-2M3 Sturmovik";;;
-"il-2m_1";"Il-2M3 Sturmovik";;;
-"il-2m_2";"Il-2M3";;;
-#
-"er-2_m105r_lu2b_shop";"Yer-2 LU-MV-2B";;;
-"er-2_m105r_lu2b_0";"OKB-240 ""Yermolaev"" | Yer-2 LU-MV-2B | Obrazets 1941";;;
-"er-2_m105r_lu2b_1";"Yer-2 LU-MV-2B";;;
-"er-2_m105r_lu2b_2";"Yer-2 LU-MV-2B";;;
-#
-"er-2_m105_mv3_shop";"Yer-2 MV-3";;;
-"er-2_m105_mv3_0";"OKB-240 ""Yermolaev"" | Yer-2 MV-3 | Obrazets 1940";;;
-"er-2_m105_mv3_1";"Yer-2 MV-3";;;
-"er-2_m105_mv3_2";"Yer-2 MV-3";;;
-#
-"pe-2-31_shop";"Pe-2-31 Peshka";;;
-"pe-2-31_0";"NKVD Central Design Bureau №29 | Pe-2-31 Peshka";;;
-"pe-2-31_1";"Pe-2-31 Peshka";;;
-"pe-2-31_2";"Pe-2-31";;;
-#
-"pe-2-83_shop";"Pe-2-83 Peshka";;;
-"pe-2-83_0";"NKVD Central Design Bureau №29 | Pe-2-83 Peshka";;;
-"pe-2-83_1";"Pe-2-83 Peshka";;;
-"pe-2-83_2";"Pe-2-83";;;
-#
-"pe-2-110_shop";"Pe-2-110 Peshka";;;
-"pe-2-110_0";"NKVD Central Design Bureau №29 | Pe-2-110 Peshka";;;
-"pe-2-110_1";"Pe-2-110 Peshka";;;
-"pe-2-110_2";"Pe-2-110";;;
-#
-"pe-2-205_shop";"Pe-2-205 Peshka";;;
-"pe-2-205_0";"NKVD Central Design Bureau №29 | Pe-2-205 Peshka";;;
-"pe-2-205_1";"Pe-2-205 Peshka";;;
-"pe-2-205_2";"Pe-2-205";;;
-#
-"pe-2-359_shop";"Pe-2-359 Peshka";;;
-"pe-2-359_0";"NKVD Central Design Bureau №29 | Pe-2-359 Peshka";;;
-"pe-2-359_1";"Pe-2-359 Peshka";;;
-"pe-2-359_2";"Pe-2-359";;;
-#
-"pe-2_shop";"Pe-2 Peshka";;;
-"pe-2_0";"NKVD Central Design Bureau №29 | Pe-2 Peshka";;;
-"pe-2_1";"Pe-2 Peshka";;;
-"pe-2_2";"Pe-2";;;
-#
-"pe-8_m82_shop";"Pe-8";;;
-"pe-8_m82_0";"NKVD Central Design Bureau №29 | Pe-8";;;
-"pe-8_m82_1";"Pe-8";;;
-"pe-8_m82_2";"Pe-8";;;
-#
-"er-2_ach30b_late_shop";"Yer-2/ACh-30B (1941)";;;
-"er-2_ach30b_late_0";"OKB-240 ""Yermolaev"" | Yer-2 | ACh-30B Engines | 1941 Model";;;
-"er-2_ach30b_late_1";"Yer-2/ACh-30B (1941)";;;
-"er-2_ach30b_late_2";"Yer-2 (1941)";;;
-#
-"er-2_ach30b_early_shop";"Yer-2/ACh-30B (1940)";;;
-"er-2_ach30b_early_0";"OKB-240 ""Yermolaev"" | Yer-2 | ACh-30B Engines | 1940 Model";;;
-"er-2_ach30b_early_1";"Yer-2/ACh-30B (1940)";;;
-"er-2_ach30b_early_2";"Yer-2 (1940)";;;
-#
-"yak-9t_shop";"Yak-9T ";;;
-"yak-9t_0";"OKB-115 ""Yakovlev"" | Yak-9T """"";;;
-"yak-9t_1";"Yak-9T ";;;
-"yak-9t_2";"Yak-9T";;;
-#
-"yak-9k_shop";"Yak-9K ";;;
-"yak-9k_0";"OKB-115 ""Yakovlev"" | Yak-9K """"";;;
-"yak-9k_1";"Yak-9K ";;;
-"yak-9k_2";"Yak-9K";;;
-#
-"yak-3_shop";"Yak-3 (1944)";;;
-"yak-3_0";"OKB-115 ""Yakovlev"" | Yak-3 (1944)";;;
-"yak-3_1";"Yak-3  (1944)";;;
-"yak-3_2";"Yak-3 (1944)";;;
-#
-"yak-9u_shop";"Yak-9U ";;;
-"yak-9u_0";"OKB-115 ""Yakovlev"" | Yak-9U """"";;;
-"yak-9u_1";"Yak-9U ";;;
-"yak-9u_2";"Yak-9U";;;
-#
-"su-8_shop";"Su-8 DDBSh";;;
-"su-8_0";"OKB-51 ""Sukhoi"" | Su-8 | Dvukhmotornyy Dvukhmestnyy Bronirovannyy Shturmovik";;;
-"su-8_1";"Su-8 DDBSh";;;
-"su-8_2";"Su-8";;;
-#
-"be_6_shop";"Be-6 Madge";;;
-"be_6_0";"OKB-49 ""Beriev"" | Be-6 Madge";;;
-"be_6_1";"Be-6 Madge";;;
-"be_6_2";"Be-6";;;
-#
-"yak-3p_shop";"Yak-3P";;;
-"yak-3p_0";"OKB-115 ""Yakovlev"" | Yak-3P """"";;;
-"yak-3p_1";"Yak-3P ";;;
-"yak-3p_2";"Yak-3P";;;
-#
-"yak-9p_shop";"Yak-9P";;;
-"yak-9p_0";"OKB-115 ""Yakovlev"" | Yak-9P """"";;;
-"yak-9p_1";"Yak-9P ";;;
-"yak-9p_2";"Yak-9P";;;
-#
-"yak-3u_shop";"Yak-3U";;;
-"yak-3u_0";"OKB-115 ""Yakovlev"" | Yak-3U """"";;;
-"yak-3u_1";"Yak-3U ";;;
-"yak-3u_2";"Yak-3U";;;
-#
-"yak-9ut_shop";"Yak-9UT";;;
-"yak-9ut_0";"OKB-115 ""Yakovlev"" | Yak-9UT """"";;;
-"yak-9ut_1";"Yak-9UT ";;;
-"yak-9ut_2";"Yak-9UT";;;
-#
-"i_225_shop";"I-225";;;
-"i_225_0";"OKB-155 ""Mikoyan i Gurevich"" | I-225";;;
-"i_225_1";"I-225";;;
-"i_225_2";"I-225";;;
-#
-"la-9_shop";"La-9 Fang";;;
-"la-9_0";"OKB-301 ""Lavochkin"" | La-9 Fang";;;
-"la-9_1";"La-9 Fang";;;
-"la-9_2";"La-9";;;
-#
-"la-7_shop";"La-7 Fin (1944)";;;
-"la-7_0";"OKB-301 ""Lavochkin"" | La-7 Fin | 1944 Izdeliyeion Standard";;;
-"la-7_1";"La-7 Fin (1944)";;;
-"la-7_2";"La-7 (1944)";;;
-#
-"la-7b-20_shop";"La-7 Fin (1945)";;;
-"la-7b-20_0";"OKB-301 ""Lavochkin"" | La-7 | 1945 Izdeliyeion Standard Fin";;;
-"la-7b-20_1";"La-7 Fin (1945)";;;
-"la-7b-20_2";"La-7 (1945)";;;
-#
-"su-6_m71_shop";"Su-6 (1943)";;;
-"su-6_m71_0";"OKB-51 ""Sukhoi"" | Su-6 | Third Prototype, 1943";;;
-"su-6_m71_1";"Su-6 (1943)";;;
-"su-6_m71_2";"Su-6 (1943)";;;
-#
-"su-6_am42_shop";"Su-6 (1944)";;;
-"su-6_am42_0";"OKB-51 ""Sukhoi"" | Su-6 | Third Prototype, 1944";;;
-"su-6_am42_1";"Su-6 (1944)";;;
-"su-6_am42_2";"Su-6 (1944)";;;
-#
-"su_6_single_shop";"Su-6 (1942)";;;
-"su_6_single_0";"OKB-51 ""Sukhoi"" | Su-6 | Second Prototype, 1942";;;
-"su_6_single_1";"Su-6 (1942)";;;
-"su_6_single_2";"Su-6 (1942)";;;
-#
-"il-10_shop";"Il-10 Beast";;;
-"il-10_0";"OKB-39 ""Ilyushin"" | Il-10 Beast";;;
-"il-10_1";"Il-10 Beast";;;
-"il-10_2";"Il-10";;;
-#
-"il-10_1946_shop";"Il-10 Beast (1946)";;;
-"il-10_1946_0";"OKB-39 ""Ilyushin"" | Il-10 Beast (1946)";;;
-"il-10_1946_1";"Il-10 Beast (1946)";;;
-"il-10_1946_2";"Il-10 (1946)";;;
-#
-"tu-2_shop";"Tu-2S Bat";;;
-"tu-2_0";"OKB-156 ""Tupolev"" | Tu-2S Bat";;;
-"tu-2_1";"Tu-2S Bat";;;
-"tu-2_2";"Tu-2S";;;
-#
-"tu-2_early_shop";"Tu-2 Bat";;;
-"tu-2_early_0";"OKB-156 ""Tupolev"" | Tu-2 Bat";;;
-"tu-2_early_1";"Tu-2 Bat";;;
-"tu-2_early_2";"Tu-2";;;
-#
-"tu-2_postwar_shop";"Tu-2S-44 Bat";;;
-"tu-2_postwar_0";"OKB-156 ""Tupolev"" | Tu-2S-44 Bat";;;
-"tu-2_postwar_1";"Tu-2S-44 Bat";;;
-"tu-2_postwar_2";"Tu-2S-44";;;
-#
-"tu-2_postwar_late_shop";"Tu-2S-59 Bat";;;
-"tu-2_postwar_late_0";"OKB-156 ""Tupolev"" | Tu-2S-59 Bat";;;
-"tu-2_postwar_late_1";"Tu-2S-59 Bat";;;
-"tu-2_postwar_late_2";"Tu-2S-59";;;
-#
-"yak-3_vk107_shop";"Yak-3 (1945)";;;
-"yak-3_vk107_0";"OKB-115 ""Yakovlev"" | Yak-3 (1945)";;;
-"yak-3_vk107_1";"Yak-3 (1945)";;;
-"yak-3_vk107_2";"Yak-3 (1945)";;;
-#
-"bi_shop";"BI-1";;;
-"bi_0";"Bereznyak-Isayev BI-1";;;
-"bi_1";"BI-1";;;
-"bi_2";"BI-1";;;
-#
-"tu_4_shop";"Tu-4 Bull";;;
-"tu_4_0";"OKB-156 ""Tupolev"" | Tu-4 Bull";;;
-"tu_4_1";"Tu-4 Bull";;;
-"tu_4_2";"Tu-4";;;
-#
-"tu_4_killstreak_shop";"☢Tu-4 Bull";;;
-"tu_4_killstreak_0";"☢OKB-156 ""Tupolev"" | Tu-4 Bull";;;
-"tu_4_killstreak_1";"☢Tu-4 Bull";;;
-"tu_4_killstreak_2";"☢Tu-4";;;
-#
-"tu_14t_shop";"Tu-14T Bosun";;;
-"tu_14t_0";"OKB-156 ""Tupolev"" | Tu-14T Bosun";;;
-"tu_14t_1";"Tu-14T Bosun";;;
-"tu_14t_2";"Tu-14T";;;
-#
-"su_27_shop";"Su-27S Flanker-B";;;
-"su_27_0";"OKB-51 ""Sukhoi"" | Su-27S Flanker-B";;;
-"su_27_1";"Su-27S Flanker-B";;;
-"su_27_2";"Su-27S";;;
-#
-"su_27sm_shop";"Su-27SM3 Flanker-J";;;
-"su_27sm_0";"PAO Kompaniya ""Sukhoi"" | Su-27SM3 Flanker-J";;;
-"su_27sm_1";"Su-27SM3 Flanker-J";;;
-"su_27sm_2";"Su-27SM3";;;
-#
-"su_30sm_shop";"Su-30SM Flanker-H";;;
-"su_30sm_0";"PAO Kompaniya ""Sukhoi"" | Su-30SM Flanker-H";;;
-"su_30sm_1";"Su-30SM Flanker-H";;;
-"su_30sm_2";"Su-30SM";;;
-#
-"su_33_shop";"Su-33 Flanker-D";"Su-33";;
-"su_33_0";"PAO Kompaniya ""Sukhoi"" | Su-33 Flanker-D";;;
-"su_33_1";"Su-33 Flanker-D";;;
-"su_33_2";"Su-33";;;
-#
-"mig_23mld_shop";"MiG-23MLD Flogger-K";;;
-"mig_23mld_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLD Flogger-K | Izdeliye 23-18";;;
-"mig_23mld_1";"MiG-23MLD Flogger-K";;;
-"mig_23mld_2";"MiG-23MLD";;;
-#
-"mig_23ml_shop";"MiG-23MLA Flogger-G";;;
-"mig_23ml_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Izdeliye 23-12A";;;
-"mig_23ml_1";"MiG-23MLA Flogger-G";;;
-"mig_23ml_2";"MiG-23MLA";;;
-#
-"mig_29_9_13_shop";"MiG-29A Fulcrum-C";;;
-"mig_29_9_13_0";"OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-C | Izdeliye 9-13";;;
-"mig_29_9_13_1";"MiG-29A Fulcrum-C";;;
-"mig_29_9_13_2";"MiG-29A";;;
-#
-"mig_29smt_9_19_shop";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E | Izdeliye 9-19";;;
-"mig_29smt_9_19_1";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_2";"MiG-29SMT";;;
-#
-"mig_29smt_9_19_missile_test_shop";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_missile_test_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E| Izdeliye 9-19";;;
-"mig_29smt_9_19_missile_test_1";"MiG-29SMT Fulcrum-E";;;
-"mig_29smt_9_19_missile_test_2";"MiG-29SMT";;;
-#
-"su_25_shop";"Su-25 Frogfoot-A";;;
-"su_25_0";"OKB-51 ""Sukhoi"" | Su-25 Frogfoot-A";;;
-"su_25_1";"Su-25 Frogfoot-A";;;
-"su_25_2";"Su-25";;;
-#
-"su_25k_shop";"Su-25K Frogfoot-A";;;
-"su_25k_0";"OKB-51 ""Sukhoi"" | Su-25K Frogfoot-A";;;
-"su_25k_1";"Su-25K Frogfoot-A";;;
-"su_25k_2";"Su-25K";;;
-#
-"su_25t_shop";"Su-25T Frogfoot-C";;;
-"su_25t_0";"OKB-51 ""Sukhoi"" | Su-25T Frogfoot-C";;;
-"su_25t_1";"Su-25T Frogfoot-C";;;
-"su_25t_2";"Su-25T";;;
-#
-"su_25tm_shop";"Su-25TM Frogfoot-D";;;
-"su_25tm_0";"PAO Kompaniya ""Sukhoi"" | Su-25TM Frogfoot-D";;;
-"su_25tm_1";"Su-25TM Frogfoot-D";;;
-"su_25tm_2";"Su-25TM";;;
-#
-"su_25_558arz_shop";"Su-25BM Frogfoot-B";;;
-"su_25_558arz_0";"OAO 558 Aviaremontnyy Zavod | Su-25BM Frogfoot-B";;;
-"su_25_558arz_1";"Su-25BM Frogfoot-B";;;
-"su_25_558arz_2";"Su-25BM";;;
-#
-"su_25sm3_shop";"Su-25SM3 Frogfoot-E";;;
-"su_25sm3_0";"PAO Kompaniya ""Sukhoi"" | Su-25SM3 Frogfoot-E";;;
-"su_25sm3_1";"Su-25SM3 Frogfoot-E";;;
-"su_25sm3_2";"Su-25SM3";;;
-#
-"mig_23m_shop";"MiG-23M Flogger-B";;;
-"mig_23m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23M Flogger-B | Izdeliye 23-11M";;;
-"mig_23m_1";"MiG-23M Flogger-B";;;
-"mig_23m_2";"MiG-23M";;;
-#
-"mig-21_smt_shop";"MiG-21SMT Fishbed-K";;;
-"mig-21_smt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SMT Fishbed-K | Izdeliye 50";;;
-"mig-21_smt_1";"MiG-21SMT Fishbed-K";;;
-"mig-21_smt_2";"MiG-21SMT";;;
-#
-"mig-21_s_shop";"MiG-21SM Fishbed-J";;;
-"mig-21_s_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SM Fishbed-J | Izdeliye 95M";;;
-"mig-21_s_1";"MiG-21SM Fishbed-J";;;
-"mig-21_s_2";"MiG-21SM";;;
-#
-"mig-21_bis_shop";"MiG-21bis Fishbed-L";;;
-"mig-21_bis_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis Fishbed-L | Izdeliye 75A";;;
-"mig-21_bis_1";"MiG-21bis Fishbed-L";;;
-"mig-21_bis_2";"MiG-21bis";;;
-#
-"mig-21_pfm_shop";"MiG-21PFM Fishbed-D";;;
-"mig-21_pfm_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21PFM Fishbed-D | Izdeliye 94";;;
-"mig-21_pfm_1";"MiG-21PFM Fishbed-D";;;
-"mig-21_pfm_2";"MiG-21PFM";;;
-#
-"su-7b_shop";"Su-7B Fitter-A";;;
-"su-7b_0";"OKB-51 ""Sukhoi"" | Su-7B Fitter-A";;;
-"su-7b_1";"Su-7B Fitter-A";;;
-"su-7b_2";"Su-7B";;;
-#
-"su-7bkl_shop";"Su-7BKL Fitter-A";;;
-"su-7bkl_0";"OKB-51 ""Sukhoi"" | Su-7BKL Fitter-A";;;
-"su-7bkl_1";"Su-7BKL Fitter-A";;;
-"su-7bkl_2";"Su-7BKL";;;
-#
-"su-7bmk_shop";"Su-7BMK Fitter-A";;;
-"su-7bmk_0";"OKB-51 ""Sukhoi"" | Su-7BMK Fitter-A";;;
-"su-7bmk_1";"Su-7BMK Fitter-A";;;
-"su-7bmk_2";"Su-7BMK";;;
-#
-"su_17m2_shop";"Su-17M2 Fitter-D";;;
-"su_17m2_0";"OKB-51 ""Sukhoi"" | Su-17M2 Fitter-D";;;
-"su_17m2_1";"Su-17M2 Fitter-D";;;
-"su_17m2_2";"Su-17M2";;;
-#
-"su_17m4_shop";"Su-17M4 Fitter-K";;;
-"su_17m4_0";"OKB-51 ""Sukhoi"" | Su-17M4 Fitter-K";;;
-"su_17m4_1";"Su-17M4 Fitter-K";;;
-"su_17m4_2";"Su-17M4";;;
-#
-"su_22m3_shop";"Su-22M3 Fitter-G";;;
-"su_22m3_0";"OKB-51 ""Sukhoi"" | Su-22M3 Fitter-G";;;
-"su_22m3_1";"Su-22M3 Fitter-G";;;
-"su_22m3_2";"Su-22M3";;;
-#
-"su_24m_shop";"Su-24M Fencer-D";;;
-"su_24m_0";"PAO Kompaniya ""Sukhoi"" | Su-24M Fencer-D";;;
-"su_24m_1";"Su-24M Fencer-D";;;
-"su_24m_2";"Su-24M";;;
-#
-"su_34_shop";"Su-34 Fullback";;;
-"su_34_0";"PAO Kompaniya ""Sukhoi"" | Su-34 Fullback";;;
-"su_34_1";"Su-34 Fullback";;;
-"su_34_2";"Su-34";;;
-#
-"mig-19pt_shop";"MiG-19PT Farmer-B";;;
-"mig-19pt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-19PT Farmer-B";;;
-"mig-19pt_1";"MiG-19PT Farmer-B";;;
-"mig-19pt_2";"MiG-19PT";;;
-#
-"mig-21_f13_shop";"MiG-21F-13 Fishbed-C";;;
-"mig-21_f13_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21F-13 Fishbed-C | Izdeliye 74";;;
-"mig-21_f13_1";"MiG-21F-13 Fishbed-C";;;
-"mig-21_f13_2";"MiG-21F-13";;;
-#
-"yak-30d_shop";"Yak-30D";;;
-"yak-30d_0";"OKB-115 ""Yakovlev"" | Yak-30D";;;
-"yak-30d_1";"Yak-30D";;;
-"yak-30d_2";"Yak-30D";;;
-#
-"yak-38_shop";"Yak-38 Forger";;;
-"yak-38_0";"OKB-115 ""Yakovlev"" | Yak-38 Forger";;;
-"yak-38_1";"Yak-38 Forger";;;
-"yak-38_2";"Yak-38";;;
-#
-"yak-38m_shop";"Yak-38M Forger-A";;;
-"yak-38m_0";"OKB-115 ""Yakovlev"" | Yak-38M Forger-A";;;
-"yak-38m_1";"Yak-38M Forger-A";;;
-"yak-38m_2";"Yak-38M";;;
-#
-"yak-28b_shop";"Yak-28B Brewer-A";;;
-"yak-28b_0";"OKB-115 ""Yakovlev"" | Yak-28B Brewer-A";;;
-"yak-28b_1";"Yak-28B Brewer-A";;;
-"yak-28b_2";"Yak-28B";;;
-#
-"yak_141_shop";"Yak-141 Freestyle";;;
-"yak_141_0";"OKB-115 ""Yakovlev"" | Yak-141 Freestyle";;;
-"yak_141_1";"Yak-141 Freestyle";;;
-"yak_141_2";"Yak-141";;;
-#
-"mig-17_shop";"MiG-17 Fresco-A";;;
-"mig-17_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-17 Fresco-A";;;
-"mig-17_1";"MiG-17 Fresco-A";;;
-"mig-17_2";"MiG-17";;;
-#
-"mig-17_cuba_shop";"MiG-17AS Fresco-A";;;
-"mig-17_cuba_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-17AS Fresco-A";;;
-"mig-17_cuba_1";"MiG-17AS Fresco-A";;;
-"mig-17_cuba_2";"MiG-17AS";;;
-#
-"mig-15_ns23_shop";"MiG-15 Fagot-A";;;
-"mig-15_ns23_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15 Fagot-A";;;
-"mig-15_ns23_1";"MiG-15 Fagot-A";;;
-"mig-15_ns23_2";"MiG-15";;;
-#
-"mig-15_shop";"MiG-15bis Fagot-B";;;
-"mig-15_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15bis Fagot-B";;;
-"mig-15_1";"MiG-15bis Fagot-B";;;
-"mig-15_2";"MiG-15bis";;;
-#
-"mig-15bis_ish_shop";"MiG-15ISh Fagot-B";;;
-"mig-15bis_ish_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15ISh Fagot-B";;;
-"mig-15bis_ish_1";"MiG-15ISh Fagot-B";;;
-"mig-15bis_ish_2";"MiG-15ISh";;;
-#
-"yak-23_shop";"Yak-23 Flora";;;
-"yak-23_0";"OKB-115 ""Yakovlev"" | Yak-23 Flora";;;
-"yak-23_1";"Yak-23 Flora";;;
-"yak-23_2";"Yak-23";;;
-#
-"yak-15_shop";"Yak-15 Feather";;;
-"yak-15_0";"OKB-115 ""Yakovlev"" | Yak-15 Feather";;;
-"yak-15_1";"Yak-15 Feather";;;
-"yak-15_2";"Yak-15";;;
-#
-"yak-15_early_shop";"Yak-15-RD10 Feather";;;
-"yak-15_early_0";"OKB-115 ""Yakovlev"" | Yak-15-RD10 Feather";;;
-"yak-15_early_1";"Yak-15-RD10 Feather";;;
-"yak-15_early_2";"Yak-15-RD10";;;
-#
-"yak-17_shop";"Yak-17 Feather";;;
-"yak-17_0";"OKB-115 ""Yakovlev"" | Yak-17 Feather";;;
-"yak-17_1";"Yak-17 Feather";;;
-"yak-17_2";"Yak-17";;;
-#
-"mig-9_shop";"MiG-9 Fargo";;;
-"mig-9_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-9 Fargo";;;
-"mig-9_1";"MiG-9 Fargo";;;
-"mig-9_2";"MiG-9";;;
-#
-"mig-9_ussr_shop";"MiG-9 Fargo (1948)";;;
-"mig-9_ussr_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-9 Fargo (1948)";;;
-"mig-9_ussr_1";"MiG-9 Fargo (1948)";;;
-"mig-9_ussr_2";"MiG-9 (1948)";;;
-#
-"la_200_toriy_shop";"La-200 Toriy";;;
-"la_200_toriy_0";"OKB-301 ""Lavochkin"" | La-200 Toriy";;;
-"la_200_toriy_1";"La-200 Toriy";;;
-"la_200_toriy_2";"La-200";;;
-#
-"la-15_shop";"La-15 Fantail";;;
-"la-15_0";"OKB-301 ""Lavochkin"" | La-15 Fantail";;;
-"la-15_1";"La-15 Fantail";;;
-"la-15_2";"La-15";;;
-#
-"la_174_shop";"La-174 Fantail";;;
-"la_174_0";"OKB-301 ""Lavochkin"" | La-174 Fantail";;;
-"la_174_1";"La-174 Fantail";;;
-"la_174_2";"La-174";;;
-#
-"il_28_shop";"Il-28 Beagle-A";;;
-"il_28_0";"OKB-39 ""Ilyushin"" | Il-28 Beagle-A";;;
-"il_28_1";"Il-28 Beagle-A";;;
-"il_28_2";"Il-28";;;
-#
-"il_28sh_shop";"Il-28Sh Beagle-B";;;
-"il_28sh_0";"OKB-39 ""Ilyushin"" | Il-28Sh Beagle-B";;;
-"il_28sh_1";"Il-28Sh Beagle-B";;;
-"il_28sh_2";"Il-28Sh";;;
-#
-"su-11_shop";"Su-11 (1947)";;;
-"su-11_0";"OKB-51 ""Sukhoi"" | Su-11 | ""Aircraft KL"" (1947)";;;
-"su-11_1";"Su-11 (1947)";;;
-"su-11_2";"Su-11 (1947)";;;
-#
-"su-9_shop";"Su-9 (1946)";;;
-"su-9_0";"OKB-51 ""Sukhoi"" | Su-9 | ""Aircraft K"" (1946)";;;
-"su-9_1";"Su-9 (1946)";;;
-"su-9_2";"Su-9 (1946)";;;
-#
-"l_39za_shop";"▂L-39ZA Albatros";;;
-"l_39za_0";"▂Aero L-39ZA Albatros";;;
-"l_39za_1";"▂L-39ZA Albatros";;;
-"l_39za_2";"▂L-39ZA";;;
-#
-"mig_27m_shop";"MiG-27M Flogger-J";;;
-"mig_27m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-27M Flogger-J";;;
-"mig_27m_1";"MiG-27M Flogger-J";;;
-"mig_27m_2";"MiG-27M";;;
-#
-"mig_27k_shop";"MiG-27K Flogger-J2";;;
-"mig_27k_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-27K Flogger-J2";;;
-"mig_27k_1";"MiG-27K Flogger-J2";;;
-"mig_27k_2";"MiG-27K";;;
-#
-"i-15_1934_shop";"I-15 Chaika (1933)";;;
-"i-15_1934_0";"N. Polikarpov OKB | I-15 Chaika (1933)";;;
-"i-15_1934_1";"I-15 Chaika (1933)";;;
-"i-15_1934_2";"I-15 (1933)";;;
-#
-"i-15_1935_shop";"I-15 Chaika (1934)";;;
-"i-15_1935_0";"N. Polikarpov OKB | I-15 Chaika (1934)";;;
-"i-15_1935_1";"I-15 Chaika (1934)";;;
-"i-15_1935_2";"I-15 (1934)";;;
-#
-"i-15_1935_moscow_shop";"I-15 Chaika (1936)";;;
-"i-15_1935_moscow_0";"N. Polikarpov OKB | I-15 Chaika (1936)";;;
-"i-15_1935_moscow_1";"I-15 Chaika (1936)";;;
-"i-15_1935_moscow_2";"I-15 (1936)";;;
-#
-"i-16_type5_shop";"I-165 Ishak";;;
-"i-16_type5_0";"N. Polikarpov OKB | I-16 Ishak | Type 5 (1935)";;;
-"i-16_type5_1";"I-165 Ishak";;;
-"i-16_type5_2";"I-165";;;
-#
-"i-16_type10_shop";"I-1610 Ishak";;;
-"i-16_type10_0";"N. Polikarpov OKB | I-16 Ishak | Type 10 (1938)";;;
-"i-16_type10_1";"I-1610 Ishak";;;
-"i-16_type10_2";"I-1610";;;
-#
-"i-16_type18_shop";"I-1618 Ishak";;;
-"i-16_type18_0";"N. Polikarpov OKB | I-16 Ishak | Type 18 (1939)";;;
-"i-16_type18_1";"I-1618 Ishak";;;
-"i-16_type18_2";"I-1618";;;
-#
-"i-16_type24_shop";"I-1624 Ishak";;;
-"i-16_type24_0";"N. Polikarpov OKB | I-16 Ishak | Type 24 (1939)";;;
-"i-16_type24_1";"I-1624 Ishak";;;
-"i-16_type24_2";"I-1624";;;
-#
-"mig_3_series_1_15_shop";"I-230";;;
-"mig_3_series_1_15_0";"OKB-155 ""Mikoyan i Gurevich"" | I-230 | 1941 MiG-3U Prototype";;;
-"mig_3_series_1_15_1";"I-230";;;
-"mig_3_series_1_15_2";"I-230";;;
-#
-"i-15bis_shop";"I-15bis Chaika";;;
-"i-15bis_0";"N. Polikarpov OKB | I-15bis Chaika (1938)";;;
-"i-15bis_1";"I-15bis Chaika";;;
-"i-15bis_2";"I-15bis";;;
-#
-"i-153_m62_shop";"I-153/M-62 Chaika";;;
-"i-153_m62_0";"N. Polikarpov OKB | I-15 Chaika | Type 3 | M-62 Engine (1939)";;;
-"i-153_m62_1";"I-153/M-62 Chaika";;;
-"i-153_m62_2";"I-153/M-62";;;
-#
-"bb-1_shop";"BB-1";;;
-"bb-1_0";"OKB-51 Sukhoi | Blizhniy Bombardirovschik-1 | 1939 Su-2 Prototype";;;
-"bb-1_1";"BB-1";;;
-"bb-1_2";"BB-1";;;
-#
-"pe-3_early_shop";"Pe-3 Peshka (1941)";;;
-"pe-3_early_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3 Peshka (1941)";;;
-"pe-3_early_1";"Pe-3 Peshka (1941)";;;
-"pe-3_early_2";"Pe-3 (1941)";;;
-#
-"pe-3_shop";"Pe-3 Peshka (1942)";;;
-"pe-3_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3 Peshka (1942)";;;
-"pe-3_1";"Pe-3 Peshka (1942)";;;
-"pe-3_2";"Pe-3 (1942)";;;
-#
-"yak_2_kabb_shop";"Yak-2 KABB";;;
-"yak_2_kabb_0";"OKB-115 ""Yakovlev"" | Yak-2 | Kombinirovnnoy Artilleriysko Bombardirovochnoy Batareyey (1940)";;;
-"yak_2_kabb_1";"Yak-2 KABB";;;
-"yak_2_kabb_2";"Yak-2 KABB";;;
-#
-"sb_2m_100_shop";"SB (1936)";;;
-"sb_2m_100_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik (1936)";;;
-"sb_2m_100_1";"SB (1936)";;;
-"sb_2m_100_2";"SB (1936)";;;
-#
-"sb_2m_103c_shop";"SB (1938)";;;
-"sb_2m_103c_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik (1938)";;;
-"sb_2m_103c_1";"SB (1938)";;;
-"sb_2m_103c_2";"SB (1938)";;;
-#
-"yak-4_shop";"Yak-4";;;
-"yak-4_0";"OKB-115 ""Yakovlev"" | Yak-4";;;
-"yak-4_1";"Yak-4";;;
-"yak-4_2";"Yak-4";;;
-#
-"ar_2_shop";"Ar-2";;;
-"ar_2_0";"Tsentral'nyy Aerogidrodinamicheskiy Institut (TsAGI) | Ar-2";;;
-"ar_2_1";"Ar-2";;;
-"ar_2_2";"Ar-2";;;
-#
-"sb_2m_103u_shop";"SB-2M (1940)";;;
-"sb_2m_103u_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik-2M (1940)";;;
-"sb_2m_103u_1";"SB-2M (1940)";;;
-"sb_2m_103u_2";"SB-2M (1940)";;;
-#
-"sb_2m_105_shop";"SB-2M (1941)";;;
-"sb_2m_105_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik-2M (1941)";;;
-"sb_2m_105_1";"SB-2M (1941)";;;
-"sb_2m_105_2";"SB-2M (1941)";;;
-#
-"po-2_shop";"Po-2 Kukuruznik";;;
-"po-2_0";"N. Polikarpov OKB | Po-2 Kukuruznik (1929)";;;
-"po-2_1";"Po-2 Kukuruznik";;;
-"po-2_2";"Po-2";;;
-#
-"po-2m_shop";"Po-2M Kukuruznik";;;
-"po-2m_0";"N. Polikarpov OKB | Po-2M Kukuruznik (1931)";;;
-"po-2m_1";"Po-2M Kukuruznik ";;;
-"po-2m_2";"Po-2M";;;
-#
-"su-2_m82_shop";"Su-2/M-82";;;
-"su-2_m82_0";"OKB-51 Sukhoi | Su-2 | M-82 Engine";;;
-"su-2_m82_1";"Su-2/M-82";;;
-"su-2_m82_2";"Su-2/M-82";;;
-#
-"su-2_mv5_shop";"Su-2 MV-5";;;
-"su-2_mv5_0";"OKB-51 Sukhoi | Su-2 | MV-5 Dorsal Turret";;;
-"su-2_mv5_1";"Su-2 MV-5";;;
-"su-2_mv5_2";"Su-2 MV-5";;;
-#
-"su-2_tss1_shop";"Su-2 TSS-1";;;
-"su-2_tss1_0";"OKB-51 Sukhoi | Su-2 | TSS-1 Turret";;;
-"su-2_tss1_1";"Su-2 TSS-1";;;
-"su-2_tss1_2";"Su-2 TSS-1";;;
-#
-"mbr-2_shop";"MBR-2bis Korova";;;
-"mbr-2_0";"OKB-49 Beriev | MBR-2bis Korova (1935)";;;
-"mbr-2_1";"MBR-2bis Korova";;;
-"mbr-2_2";"MBR-2bis";;;
-#
-"i-15bis_krasnolutsky_shop";"I-15bis [Krasnolutsky]";;;
-"i-15bis_krasnolutsky_0";"N. Polikarpov OKB | Krasnolutsky's I-15bis (1938)";;;
-"i-15bis_krasnolutsky_1";"I-15bis [Krasnolutsky]";;;
-"i-15bis_krasnolutsky_2";"I-15bis [Krasnolutsky]";;;
-#
-"pby-5a_shop";"▂PBY-5A Catalina";;;
-"pby-5a_0";"▂Consolidated Aircraft | PBY-5A Catalina";;;
-"pby-5a_1";"▂PBY-5A Catalina";;;
-"pby-5a_2";"▂PBY-5A";;;
-#
-"hp52_hampden_tbmk1_ussr_utk1_shop";"▂Hampden Mk.I UTK-1";;;
-"hp52_hampden_tbmk1_ussr_utk1_0";"▂Handley Page | HP.52 Hampden | Mk.I | UTK-1 Dorsal Turret";;;
-"hp52_hampden_tbmk1_ussr_utk1_1";"▂Hampden Mk.I UTK-1";;;
-"hp52_hampden_tbmk1_ussr_utk1_2";"▂Hampden Mk.I UTK-1";;;
-#
-"i-153_m62_zhukovskiy_shop";"I-153 Chaika [Zhukovsky]";;;
-"i-153_m62_zhukovskiy_0";"N. Polikarpov OKB | Zhukovsky's I-15 Chaika | Type 3 (1939)";;;
-"i-153_m62_zhukovskiy_1";"I-153 Chaika [Zhukovsky]";;;
-"i-153_m62_zhukovskiy_2";"I-153 [Zhukovsky]";;;
-#
-"p-40e_ussr_shop";"▂P-40E-1 Kittyhawk";;;
-"p-40e_ussr_0";"▂Curtiss-Wright Corporation | P-40E-1 Kittyhawk | Block 1";;;
-"p-40e_ussr_1";"▂P-40E-1 Kittyhawk";;;
-"p-40e_ussr_2";"▂P-40E-1";;;
-#
-"i_29_shop";"I-29";;;
-"i_29_0";"OKB-115 ""Yakovlev"" | I-29 (1940)";;;
-"i_29_1";"I-29";;;
-"i_29_2";"I-29";;;
-#
-"hurricanemkii_ussr_shop";"▂Hurricane Mk.IIB";;;
-"hurricanemkii_ussr_0";"▂Hawker Aircraft | Hurricane | Mk.IIB";;;
-"hurricanemkii_ussr_1";"▂Hurricane Mk.IIB";;;
-"hurricanemkii_ussr_2";"▂Hurricane Mk.IIB";;;
-#
-"il_2_m82_shop";"Il-2/M-82IR Sturmovik";;;
-"il_2_m82_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik | M-82IR Engine";;;
-"il_2_m82_1";"Il-2/M-82IR Sturmovik ";;;
-"il_2_m82_2";"Il-2/M-82IR";;;
-#
-"i-153p_shop";"I-153P Chaika";;;
-"i-153p_0";"N. Polikarpov OKB | I-15 Chaika | Type 3 | Pushechnyy";;;
-"i-153p_1";"I-153P Chaika";;;
-"i-153p_2";"I-153P";;;
-#
-"i_180_shop";"I-180S";;;
-"i_180_0";"N. Polikarpov OKB | I-180S";;;
-"i_180_1";"I-180S";;;
-"i_180_2";"I-180S";;;
-#
-"p-39k_1_shop";"▂P-39K-1 Aircobra";;;
-"p-39k_1_0";"▂Bell Aircraft | P-39K-1 Aircobra | Model 26A";;;
-"p-39k_1_1";"▂P-39K-1 Aircobra";;;
-"p-39k_1_2";"▂P-39K-1";;;
-#
-"lagg-3-34_shop";"LaGG-3-34";;;
-"lagg-3-34_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 34th Series";;;
-"lagg-3-34_1";"LaGG-3-34";;;
-"lagg-3-34_2";"LaGG-3-34";;;
-#
-"lagg-i-301_shop";"I-301";;;
-"lagg-i-301_0";" OKB-301 ""Lavochkin"" | I-301 | 1940 LaGG-3 Prototype";;;
-"lagg-i-301_1";"I-301";;;
-"lagg-i-301_2";"I-301";;;
-#
-"yak-1_early_shop";"Yak-1";;;
-"yak-1_early_0";"OKB-115 ""Yakovlev"" | Yak-1";;;
-"yak-1_early_1";"Yak-1";;;
-"yak-1_early_2";"Yak-1";;;
-#
-"yak-1b_shop";"Yak-1B";;;
-"yak-1b_0";"OKB-115 ""Yakovlev"" | Yak-1B";;;
-"yak-1b_1";"Yak-1B";;;
-"yak-1b_2";"Yak-1B";;;
-#
-"yak-7b_shop";"Yak-7B";;;
-"yak-7b_0";"OKB-115 ""Yakovlev"" | Yak-7B";;;
-"yak-7b_1";"Yak-7B";;;
-"yak-7b_2";"Yak-7B";;;
-#
-"yak-9_shop";"Yak-9 ";;;
-"yak-9_0";"OKB-115 ""Yakovlev"" | Yak-9";;;
-"yak-9_1";"Yak-9 ";;;
-"yak-9_2";"Yak-9";;;
-#
-"yak-9b_shop";"Yak-9B";;;
-"yak-9b_0";"OKB-115 ""Yakovlev"" | Yak-9B";;;
-"yak-9b_1";"Yak-9B";;;
-"yak-9b_2";"Yak-9B";;;
-#
-"mig_3_series_1_15_bk_pod_shop";"I-230 (BK)";;;
-"mig_3_series_1_15_bk_pod_0";"OKB-155 ""Mikoyan i Gurevich"" | I-230 | MiG-3U Prototype | BK Gunpods";;;
-"mig_3_series_1_15_bk_pod_1";"I-230 (BK)";;;
-"mig_3_series_1_15_bk_pod_2";"I-230 (BK)";;;
-#
-"mig_3_series_34_shop";"MiG-3-34";;;
-"mig_3_series_34_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-3 | 34th Series";;;
-"mig_3_series_34_1";"MiG-3-34";;;
-"mig_3_series_34_2";"MiG-3-34";;;
-#
-"i-16_type27_shop";"I-1627 Ishak";;;
-"i-16_type27_0";"N. Polikarpov OKB | I-16 Ishak | Type 27";;;
-"i-16_type27_1";"I-1627 Ishak";;;
-"i-16_type27_2";"I-1627";;;
-#
-"lagg-3-8_shop";"LaGG-3-8";;;
-"lagg-3-8_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 8th Series";;;
-"lagg-3-8_1";"LaGG-3-8";;;
-"lagg-3-8_2";"LaGG-3-8";;;
-#
-"lagg-3-11_shop";"LaGG-3-11";;;
-"lagg-3-11_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 11th Series";;;
-"lagg-3-11_1";"LaGG-3-11";;;
-"lagg-3-11_2";"LaGG-3-11";;;
-#
-"lagg-3-35_shop";"LaGG-3-35";;;
-"lagg-3-35_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 35th Series";;;
-"lagg-3-35_1";"LaGG-3-35";;;
-"lagg-3-35_2";"LaGG-3-35";;;
-#
-"lagg-3-66_shop";"LaGG-3-66";;;
-"lagg-3-66_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 66th Series";;;
-"lagg-3-66_1";"LaGG-3-66";;;
-"lagg-3-66_2";"LaGG-3-66";;;
-#
-"la-5_shop";"La-5";;;
-"la-5_0";"OKB-301 ""Lavochkin"" | La-5";;;
-"la-5_1";"La-5";;;
-"la-5_2";"La-5";;;
-#
-"la-5_type39_shop";"La-5F";;;
-"la-5_type39_0";"OKB-301 ""Lavochkin"" | La-5F";;;
-"la-5_type39_1";"La-5F";;;
-"la-5_type39_2";"La-5F";;;
-#
-"il_2_1941_shop";"Il-2 Sturmovik (1941)";;;
-"il_2_1941_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik (1941)";;;
-"il_2_1941_1";"Il-2 Sturmovik (1941)";;;
-"il_2_1941_2";"Il-2 (1941)";;;
-#
-"il-2i_shop";"Il-2 Sturmovik (1942)";;;
-"il-2i_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik (1942)";;;
-"il-2i_1";"Il-2 Sturmovik (1942)";;;
-"il-2i_2";"Il-2 (1942)";;;
-#
-"il_2_37_1943_shop";"Il-2M3M Sturmovik";;;
-"il_2_37_1943_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik | Type 3M";;;
-"il_2_37_1943_1";"Il-2M3M Sturmovik";;;
-"il_2_37_1943_2";"Il-2M3M";;;
-#
-"pe-3_bis_shop";"Pe-3bis Peshka";;;
-"pe-3_bis_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3bis Peshka";;;
-"pe-3_bis_1";"Pe-3bis Peshka";;;
-"pe-3_bis_2";"Pe-3bis";;;
-#
-"db_3b_shop";"DB-3B";;;
-"db_3b_0";"OKB-39 ""Ilyushin"" | Dalniy Bombardirovshchik-3B";;;
-"db_3b_1";"DB-3B";;;
-"db_3b_2";"DB-3B";;;
-#
-"il-4_shop";"Il-4 Bob";;;
-"il-4_0";"OKB-39 ""Ilyushin"" | Il-4 Bob";;;
-"il-4_1";"Il-4 Bob";;;
-"il-4_2";"Il-4";;;
-#
-"pe-2-1_shop";"Pe-2-1 Peshka";;;
-"pe-2-1_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-2-1 Peshka";;;
-"pe-2-1_1";"Pe-2-1 Peshka";;;
-"pe-2-1_2";"Pe-2-1";;;
-#
-"su_30mk2v_venezuela_shop";"◡Su-30MKV Flanker-G+";;;
-"su_30mk2v_venezuela_0";"PAO Kompaniya ""Sukhoi"" | ◡Su-30MKV Flanker-G+";;;
-"su_30mk2v_venezuela_1";"◡Su-30MKV Flanker-G+";;;
-"su_30mk2v_venezuela_2";"◡Su-30MKV";;;
-#
-"yak_1_litvyak_shop";"Yak-1 [Litvyak]";;;
-"yak_1_litvyak_0";"OKB-115 | S. A. Yakovlev | Litvyak's Yak-1";;;
-"yak_1_litvyak_1";"Yak-1 [Litvyak]";;;
-"yak_1_litvyak_2";"Yak-1 [Litvyak]";;;
-#
-mig_25pd_shop;MiG-25PD Foxbat-E;;;
-mig_25pd_0;"OKB-155 ""Mikoyan i Gurevich"" | MiG-25PD Foxbat-E";;;
-mig_25pd_1;MiG-25PD Foxbat-E;;;
-mig_25pd_2;MiG-25PD;;;
-#
-su_30sm2_shop;Su-30SM2 Flanker-H;;;
-su_30sm2_0;"PAO Kompaniya ""Sukhoi"" | Su-30SM2 Flanker-H";;;
-su_30sm2_1;Su-30SM2 Flanker-H;;;
-su_30sm2_2;Su-30SM2;;;
-#
-"shop/group/ar_group";"Ar-2/SB-2";;;
-"shop/group/db_3_group";"DB-3B/Il-4 Bob";;;
-"shop/group/il-2i_group";"Il-2 Sturmovik";;;
-"shop/group/la_5_group";"La-5/5F";;;
-"shop/group/yak-9tk_group";"Yak-9T/K";;;
-"shop/group/yak-3up_group";"Yak-3U/9UT";;;
-"shop/group/il_28_group";"Il-28 Beagle";;;
-"shop/group/la_200_group";"La-200/La-15";;;
-"shop/group/su-7_group";"Su-7B/BKL Fitter";;;
-"shop/group/mig-19_group";"MiG-19/MiG-21";;;
-"shop/group/mig_27_group";"MiG-27 Flogger";;;
-"shop/group/mig-23m_group";"MiG-23 Flogger";;;
-"shop/group/mig-21_group";"MiG-21 Fishbed";;;
-"shop/group/mig-15_group";"MiG-15 Fagot";;;
-"shop/group/mig-9_group";"MiG-9 Fargo";;;
-"shop/group/il-10_group";"Il-10 Beast";;;
-"shop/group/yak-1_group";"Yak-1";;;
-"shop/group/yak-9_group";"Yak-9/9B";;;
-"shop/group/yak-3_group";"Yak-3/9U";;;
-"shop/group/yak-9u_group";"Yak-9U";;;
-"shop/group/er-2_ach30b_group";"Yer-2/ACh-30B";;;
-"shop/group/lagg-3_late_group";"LaGG-3-35/66";;;
-"shop/group/pe-2_early_group";"Pe-2 Peshka (Early)";;;
-"shop/group/pe-2_late_group";"Pe-2 Peshka (Late)";;;
-"shop/group/tu-2_group";"Tu-2 Bat";;;
-"shop/group/er-2_late_group";"Yer-2/ACh-30B";;;
-"shop/group/il-2m_group";"Il-2M Sturmovik";;;
-"shop/group/lagg-3_group";"LaGG-3-8/11";;;
+"<ID|readonly|noverify>";"<English>"
+#
+"itp_m1_shop";"ITP (M-1)"
+"itp_m1_0";"N. Polikarpov OKB | Istrebitel Tyazholiy Pushechniy (ITP) | M-1 Prototype, 1942"
+"itp_m1_1";"ITP (M-1)"
+"itp_m1_2";"ITP (M-1)"
+#
+"tis_ma_shop";"TIS (MA)"
+"tis_ma_0";"N. Polikarpov OKB | Tyazholyy Istrebitel' Soprovozhdeniya (TIS) | MA Prototype, 1941"
+"tis_ma_1";"TIS (MA)"
+"tis_ma_2";"TIS (MA)"
+#
+"il_8_1944_shop";"Il-8 Sturmovik (1944)"
+"il_8_1944_0";"OKB-39 ""Ilyushin"" | Il-8 Sturmovik | Obrazets 1944"
+"il_8_1944_1";"Il-8 Sturmovik (1944)"
+"il_8_1944_2";"Il-8 (1944)"
+#
+"yak-3_eremin_shop";"Yak-3  (1944) [Eremin]"
+"yak-3_eremin_0";"OKB-115 ""Yakovlev"" | Eremin's Yak-3 | Obrazets 1944"
+"yak-3_eremin_1";"Yak-3  (1944) [Eremin]"
+"yak-3_eremin_2";"Yak-3 (1944) [Eremin]"
+#
+"b_25j_30_vvs_ussr_shop";"☭B-25J-30 Mitchell"
+"b_25j_30_vvs_ussr_0";"☭North American Aviation | B-25J-30 Mitchell | Block 30"
+"b_25j_30_vvs_ussr_1";"☭B-25J-30 Mitchell"
+"b_25j_30_vvs_ussr_2";"☭B-25J-30"
+#
+"p-47d_ussr_shop";"☭P-47D-27 Thunderbolt"
+"p-47d_ussr_0";"☭Republic Aviation Corporation | P-47D-27 Thunderbolt | Block 27"
+"p-47d_ussr_1";"☭P-47D-27 Thunderbolt"
+"p-47d_ussr_2";"☭P-47D-27"
+#
+"p-63a-5_ussr_shop";"☭P-63A-5 Kingcobra"
+"p-63a-5_ussr_0";"☭Bell Aircraft Corporation | P-63A-5 Kingcobra | Block 5"
+"p-63a-5_ussr_1";"☭P-63A-5 Kingcobra"
+"p-63a-5_ussr_2";"☭P-63A-5"
+#
+"p-63c-5_ussr_shop";"☭P-63C-5 Kingcobra"
+"p-63c-5_ussr_0";"☭Bell Aircraft Corporation | P-63C-5 Kingcobra | Block 5"
+"p-63c-5_ussr_1";"☭P-63C-5 Kingcobra"
+"p-63c-5_ussr_2";"☭P-63C-5"
+#
+"a_20g_30_ussr_shop";"☭A-20G-30 Havoc"
+"a_20g_30_ussr_0";"☭Douglas Aircraft Company | A-20G-30 Havoc | Block 30"
+"a_20g_30_ussr_1";"☭A-20G-30 Havoc"
+"a_20g_30_ussr_2";"☭A-20G-30"
+#
+"i_185_m71_standard_shop";"I-185/M-71"
+"i_185_m71_standard_0";"N. Polikarpov OKB | I-185 | Obrazets 1942, M-71 Engine"
+"i_185_m71_standard_1";"I-185/M-71"
+"i_185_m71_standard_2";"I-185/M-71"
+#
+"i_185_m82_shop";"I-185/M-82"
+"i_185_m82_0";"N. Polikarpov OKB | I-185 | 1940 Prototype, M-82 Engine"
+"i_185_m82_1";"I-185/M-82"
+"i_185_m82_2";"I-185/M-82"
+#
+"la-5fn_shop";"La-5FN"
+"la-5fn_0";"OKB-301 ""Lavochkin"" | La-5FN"
+"la-5fn_1";"La-5FN"
+"la-5fn_2";"La-5FN"
+#
+"il_2m_1943_shop";"Il-2M Sturmovik (1943)"
+"il_2m_1943_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik | Obrazets 1943"
+"il_2m_1943_1";"Il-2M Sturmovik (1943)"
+"il_2m_1943_2";"Il-2M (1943)"
+#
+"il-2m_mstitel_shop";"Il-2M Sturmovik ""Mstitel"""
+"il-2m_mstitel_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik ""Мstitel"""
+"il-2m_mstitel_1";"Il-2M Sturmovik ""Mstitel"""
+"il-2m_mstitel_2";"Il-2M ""Мstitel"""
+#
+"il-2m_shop";"Il-2M3 Sturmovik"
+"il-2m_0";"OKB-39 ""Ilyushin"" | Il-2M3 Sturmovik"
+"il-2m_1";"Il-2M3 Sturmovik"
+"il-2m_2";"Il-2M3"
+#
+"er-2_m105r_lu2b_shop";"Yer-2 LU-MV-2B"
+"er-2_m105r_lu2b_0";"OKB-240 ""Yermolaev"" | Yer-2 LU-MV-2B | Obrazets 1941"
+"er-2_m105r_lu2b_1";"Yer-2 LU-MV-2B"
+"er-2_m105r_lu2b_2";"Yer-2 LU-MV-2B"
+#
+"er-2_m105_mv3_shop";"Yer-2 MV-3"
+"er-2_m105_mv3_0";"OKB-240 ""Yermolaev"" | Yer-2 MV-3 | Obrazets 1940"
+"er-2_m105_mv3_1";"Yer-2 MV-3"
+"er-2_m105_mv3_2";"Yer-2 MV-3"
+#
+"pe-2-31_shop";"Pe-2-31 Peshka"
+"pe-2-31_0";"NKVD Central Design Bureau №29 | Pe-2-31 Peshka"
+"pe-2-31_1";"Pe-2-31 Peshka"
+"pe-2-31_2";"Pe-2-31"
+#
+"pe-2-83_shop";"Pe-2-83 Peshka"
+"pe-2-83_0";"NKVD Central Design Bureau №29 | Pe-2-83 Peshka"
+"pe-2-83_1";"Pe-2-83 Peshka"
+"pe-2-83_2";"Pe-2-83"
+#
+"pe-2-110_shop";"Pe-2-110 Peshka"
+"pe-2-110_0";"NKVD Central Design Bureau №29 | Pe-2-110 Peshka"
+"pe-2-110_1";"Pe-2-110 Peshka"
+"pe-2-110_2";"Pe-2-110"
+#
+"pe-2-205_shop";"Pe-2-205 Peshka"
+"pe-2-205_0";"NKVD Central Design Bureau №29 | Pe-2-205 Peshka"
+"pe-2-205_1";"Pe-2-205 Peshka"
+"pe-2-205_2";"Pe-2-205"
+#
+"pe-2-359_shop";"Pe-2-359 Peshka"
+"pe-2-359_0";"NKVD Central Design Bureau №29 | Pe-2-359 Peshka"
+"pe-2-359_1";"Pe-2-359 Peshka"
+"pe-2-359_2";"Pe-2-359"
+#
+"pe-2_shop";"Pe-2 Peshka"
+"pe-2_0";"NKVD Central Design Bureau №29 | Pe-2 Peshka"
+"pe-2_1";"Pe-2 Peshka"
+"pe-2_2";"Pe-2"
+#
+"pe-8_m82_shop";"Pe-8"
+"pe-8_m82_0";"NKVD Central Design Bureau №29 | Pe-8"
+"pe-8_m82_1";"Pe-8"
+"pe-8_m82_2";"Pe-8"
+#
+"er-2_ach30b_late_shop";"Yer-2/ACh-30B (1941)"
+"er-2_ach30b_late_0";"OKB-240 ""Yermolaev"" | Yer-2 | ACh-30B Engines | 1941 Model"
+"er-2_ach30b_late_1";"Yer-2/ACh-30B (1941)"
+"er-2_ach30b_late_2";"Yer-2 (1941)"
+#
+"er-2_ach30b_early_shop";"Yer-2/ACh-30B (1940)"
+"er-2_ach30b_early_0";"OKB-240 ""Yermolaev"" | Yer-2 | ACh-30B Engines | 1940 Model"
+"er-2_ach30b_early_1";"Yer-2/ACh-30B (1940)"
+"er-2_ach30b_early_2";"Yer-2 (1940)"
+#
+"yak-9t_shop";"Yak-9T "
+"yak-9t_0";"OKB-115 ""Yakovlev"" | Yak-9T"
+"yak-9t_1";"Yak-9T "
+"yak-9t_2";"Yak-9T"
+#
+"yak-9k_shop";"Yak-9K "
+"yak-9k_0";"OKB-115 ""Yakovlev"" | Yak-9K"
+"yak-9k_1";"Yak-9K "
+"yak-9k_2";"Yak-9K"
+#
+"yak-3_shop";"Yak-3 (1944)"
+"yak-3_0";"OKB-115 ""Yakovlev"" | Yak-3 (1944)"
+"yak-3_1";"Yak-3  (1944)"
+"yak-3_2";"Yak-3 (1944)"
+#
+"yak-9u_shop";"Yak-9U "
+"yak-9u_0";"OKB-115 ""Yakovlev"" | Yak-9U"
+"yak-9u_1";"Yak-9U "
+"yak-9u_2";"Yak-9U"
+#
+"su-8_shop";"Su-8 DDBSh"
+"su-8_0";"OKB-51 ""Sukhoi"" | Su-8 | Dvukhmotornyy Dvukhmestnyy Bronirovannyy Shturmovik"
+"su-8_1";"Su-8 DDBSh"
+"su-8_2";"Su-8"
+#
+"be_6_shop";"Be-6 Madge"
+"be_6_0";"OKB-49 ""Beriev"" | Be-6 Madge"
+"be_6_1";"Be-6 Madge"
+"be_6_2";"Be-6"
+#
+"yak-3p_shop";"Yak-3P"
+"yak-3p_0";"OKB-115 ""Yakovlev"" | Yak-3P"
+"yak-3p_1";"Yak-3P "
+"yak-3p_2";"Yak-3P"
+#
+"yak-9p_shop";"Yak-9P"
+"yak-9p_0";"OKB-115 ""Yakovlev"" | Yak-9P"
+"yak-9p_1";"Yak-9P "
+"yak-9p_2";"Yak-9P"
+#
+"yak-3u_shop";"Yak-3U"
+"yak-3u_0";"OKB-115 ""Yakovlev"" | Yak-3U"
+"yak-3u_1";"Yak-3U "
+"yak-3u_2";"Yak-3U"
+#
+"yak-9ut_shop";"Yak-9UT"
+"yak-9ut_0";"OKB-115 ""Yakovlev"" | Yak-9UT"
+"yak-9ut_1";"Yak-9UT "
+"yak-9ut_2";"Yak-9UT"
+#
+"i_225_shop";"I-225"
+"i_225_0";"OKB-155 ""Mikoyan i Gurevich"" | I-225"
+"i_225_1";"I-225"
+"i_225_2";"I-225"
+#
+"la-9_shop";"La-9"
+"la-9_0";"OKB-301 ""Lavochkin"" | La-9"
+"la-9_1";"La-9"
+"la-9_2";"La-9"
+#
+"la-7_shop";"La-7 (1944)"
+"la-7_0";"OKB-301 ""Lavochkin"" | La-7 | 1944 Izdeliyeion Standard"
+"la-7_1";"La-7 (1944)"
+"la-7_2";"La-7 (1944)"
+#
+"la-7b-20_shop";"La-7 (1945)"
+"la-7b-20_0";"OKB-301 ""Lavochkin"" | La-7 | 1945 Izdeliyeion Standard"
+"la-7b-20_1";"La-7 (1945)"
+"la-7b-20_2";"La-7 (1945)"
+#
+"su-6_m71_shop";"Su-6 (1943)"
+"su-6_m71_0";"OKB-51 ""Sukhoi"" | Su-6 | Third Prototype, 1943"
+"su-6_m71_1";"Su-6 (1943)"
+"su-6_m71_2";"Su-6 (1943)"
+#
+"su-6_am42_shop";"Su-6 (1944)"
+"su-6_am42_0";"OKB-51 ""Sukhoi"" | Su-6 | Third Prototype, 1944"
+"su-6_am42_1";"Su-6 (1944)"
+"su-6_am42_2";"Su-6 (1944)"
+#
+"su_6_single_shop";"Su-6 (1942)"
+"su_6_single_0";"OKB-51 ""Sukhoi"" | Su-6 | Second Prototype, 1942"
+"su_6_single_1";"Su-6 (1942)"
+"su_6_single_2";"Su-6 (1942)"
+#
+"il-10_shop";"Il-10 Beast"
+"il-10_0";"OKB-39 ""Ilyushin"" | Il-10 Beast"
+"il-10_1";"Il-10 Beast"
+"il-10_2";"Il-10"
+#
+"il-10_1946_shop";"Il-10 Beast (1946)"
+"il-10_1946_0";"OKB-39 ""Ilyushin"" | Il-10 Beast (1946)"
+"il-10_1946_1";"Il-10 Beast (1946)"
+"il-10_1946_2";"Il-10 (1946)"
+#
+"tu-2_shop";"Tu-2S"
+"tu-2_0";"OKB-156 ""Tupolev"" | Tu-2S"
+"tu-2_1";"Tu-2S"
+"tu-2_2";"Tu-2S"
+#
+"tu-2_early_shop";"Tu-2"
+"tu-2_early_0";"OKB-156 ""Tupolev"" | Tu-2"
+"tu-2_early_1";"Tu-2"
+"tu-2_early_2";"Tu-2"
+#
+"tu-2_postwar_shop";"Tu-2S-44"
+"tu-2_postwar_0";"OKB-156 ""Tupolev"" | Tu-2S-44"
+"tu-2_postwar_1";"Tu-2S-44"
+"tu-2_postwar_2";"Tu-2S-44"
+#
+"tu-2_postwar_late_shop";"Tu-2S-59"
+"tu-2_postwar_late_0";"OKB-156 ""Tupolev"" | Tu-2S-59"
+"tu-2_postwar_late_1";"Tu-2S-59"
+"tu-2_postwar_late_2";"Tu-2S-59"
+#
+"yak-3_vk107_shop";"Yak-3 (1945)"
+"yak-3_vk107_0";"OKB-115 ""Yakovlev"" | Yak-3 (1945)"
+"yak-3_vk107_1";"Yak-3 (1945)"
+"yak-3_vk107_2";"Yak-3 (1945)"
+#
+"bi_shop";"BI-1"
+"bi_0";"Bereznyak-Isayev BI-1"
+"bi_1";"BI-1"
+"bi_2";"BI-1"
+#
+"tu_4_shop";"Tu-4 Bull"
+"tu_4_0";"OKB-156 ""Tupolev"" | Tu-4 Bull"
+"tu_4_1";"Tu-4 Bull"
+"tu_4_2";"Tu-4"
+#
+"tu_4_killstreak_shop";"☢Tu-4 Bull"
+"tu_4_killstreak_0";"☢OKB-156 ""Tupolev"" | Tu-4 Bull"
+"tu_4_killstreak_1";"☢Tu-4 Bull"
+"tu_4_killstreak_2";"☢Tu-4"
+#
+"tu_14t_shop";"Tu-14T Bosun"
+"tu_14t_0";"OKB-156 ""Tupolev"" | Tu-14T Bosun"
+"tu_14t_1";"Tu-14T Bosun"
+"tu_14t_2";"Tu-14T"
+#
+"su_27_shop";"Su-27S Flanker-B"
+"su_27_0";"OKB-51 ""Sukhoi"" | Su-27S Flanker-B"
+"su_27_1";"Su-27S Flanker-B"
+"su_27_2";"Su-27S"
+#
+"su_27sm_shop";"Su-27SM3 Flanker-J"
+"su_27sm_0";"PAO Kompaniya ""Sukhoi"" | Su-27SM3 Flanker-J"
+"su_27sm_1";"Su-27SM3 Flanker-J"
+"su_27sm_2";"Su-27SM3"
+#
+"su_30sm_shop";"Su-30SM Flanker-H"
+"su_30sm_0";"PAO Kompaniya ""Sukhoi"" | Su-30SM Flanker-H"
+"su_30sm_1";"Su-30SM Flanker-H"
+"su_30sm_2";"Su-30SM"
+#
+"su_33_shop";"Su-33 Flanker-D"
+"su_33_0";"PAO Kompaniya ""Sukhoi"" | Su-33 Flanker-D"
+"su_33_1";"Su-33 Flanker-D"
+"su_33_2";"Su-33"
+#
+"mig_23mld_shop";"MiG-23MLD Flogger-K"
+"mig_23mld_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLD Flogger-K | Izdeliye 23-18"
+"mig_23mld_1";"MiG-23MLD Flogger-K"
+"mig_23mld_2";"MiG-23MLD"
+#
+"mig_23ml_shop";"MiG-23MLA Flogger-G"
+"mig_23ml_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23MLA Flogger-G | Izdeliye 23-12A"
+"mig_23ml_1";"MiG-23MLA Flogger-G"
+"mig_23ml_2";"MiG-23MLA"
+#
+"mig_29_9_13_shop";"MiG-29A Fulcrum-C"
+"mig_29_9_13_0";"OKB-155 ""Mikoyan"" | MiG-29A Fulcrum-C | Izdeliye 9-13"
+"mig_29_9_13_1";"MiG-29A Fulcrum-C"
+"mig_29_9_13_2";"MiG-29A"
+#
+"mig_29smt_9_19_shop";"MiG-29SMT Fulcrum-E"
+"mig_29smt_9_19_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E | Izdeliye 9-19"
+"mig_29smt_9_19_1";"MiG-29SMT Fulcrum-E"
+"mig_29smt_9_19_2";"MiG-29SMT"
+#
+"mig_29smt_9_19_missile_test_shop";"MiG-29SMT Fulcrum-E"
+"mig_29smt_9_19_missile_test_0";"RSO Korporatsiya ""MiG"" | MiG-29SMT Fulcrum-E| Izdeliye 9-19"
+"mig_29smt_9_19_missile_test_1";"MiG-29SMT Fulcrum-E"
+"mig_29smt_9_19_missile_test_2";"MiG-29SMT"
+#
+"su_25_shop";"Su-25 Grach"
+"su_25_0";"OKB-51 ""Sukhoi"" | Su-25 Grach / Frogfoot"
+"su_25_1";"Su-25 Grach"
+"su_25_2";"Su-25"
+#
+"su_25k_shop";"Su-25K Grach"
+"su_25k_0";"OKB-51 ""Sukhoi"" | Su-25K Grach / Frogfoot"
+"su_25k_1";"Su-25K Grach"
+"su_25k_2";"Su-25K"
+#
+"su_25t_shop";"Su-25T Grach"
+"su_25t_0";"OKB-51 ""Sukhoi"" | Su-25T Grach / Frogfoot"
+"su_25t_1";"Su-25T Grach"
+"su_25t_2";"Su-25T"
+#
+"su_25tm_shop";"Su-25TM Grach"
+"su_25tm_0";"PAO Kompaniya ""Sukhoi"" | Su-25TM Grach / Frogfoot"
+"su_25tm_1";"Su-25TM Grach"
+"su_25tm_2";"Su-25TM"
+#
+"su_25_558arz_shop";"Su-25BM Grach"
+"su_25_558arz_0";"OAO 558 Aviaremontnyy Zavod | Su-25BM Grach / Frogfoot"
+"su_25_558arz_1";"Su-25BM Grach"
+"su_25_558arz_2";"Su-25BM"
+#
+"su_25sm3_shop";"Su-25SM3 Grach"
+"su_25sm3_0";"PAO Kompaniya ""Sukhoi"" | Su-25SM3 Grach / Frogfoot"
+"su_25sm3_1";"Su-25SM3 Grach"
+"su_25sm3_2";"Su-25SM3"
+#
+"mig_23m_shop";"MiG-23M Flogger-B"
+"mig_23m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-23M Flogger-B | Izdeliye 23-11M"
+"mig_23m_1";"MiG-23M Flogger-B"
+"mig_23m_2";"MiG-23M"
+#
+"mig-21_smt_shop";"MiG-21SMT Fishbed-K"
+"mig-21_smt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SMT Fishbed-K | Izdeliye 50"
+"mig-21_smt_1";"MiG-21SMT Fishbed-K"
+"mig-21_smt_2";"MiG-21SMT"
+#
+"mig-21_s_shop";"MiG-21SM Fishbed-J"
+"mig-21_s_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21SM Fishbed-J | Izdeliye 95M"
+"mig-21_s_1";"MiG-21SM Fishbed-J"
+"mig-21_s_2";"MiG-21SM"
+#
+"mig-21_bis_shop";"MiG-21bis Fishbed-L"
+"mig-21_bis_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21bis Fishbed-L | Izdeliye 75A"
+"mig-21_bis_1";"MiG-21bis Fishbed-L"
+"mig-21_bis_2";"MiG-21bis"
+#
+"mig-21_pfm_shop";"MiG-21PFM Fishbed-D"
+"mig-21_pfm_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21PFM Fishbed-D | Izdeliye 94"
+"mig-21_pfm_1";"MiG-21PFM Fishbed-D"
+"mig-21_pfm_2";"MiG-21PFM"
+#
+"su-7b_shop";"Su-7B Fitter-A"
+"su-7b_0";"OKB-51 ""Sukhoi"" | Su-7B Fitter-A"
+"su-7b_1";"Su-7B Fitter-A"
+"su-7b_2";"Su-7B"
+#
+"su-7bkl_shop";"Su-7BKL Fitter-A"
+"su-7bkl_0";"OKB-51 ""Sukhoi"" | Su-7BKL Fitter-A"
+"su-7bkl_1";"Su-7BKL Fitter-A"
+"su-7bkl_2";"Su-7BKL"
+#
+"su-7bmk_shop";"Su-7BMK Fitter-A"
+"su-7bmk_0";"OKB-51 ""Sukhoi"" | Su-7BMK Fitter-A"
+"su-7bmk_1";"Su-7BMK Fitter-A"
+"su-7bmk_2";"Su-7BMK"
+#
+"su_17m2_shop";"Su-17M2 Fitter-D"
+"su_17m2_0";"OKB-51 ""Sukhoi"" | Su-17M2 Fitter-D"
+"su_17m2_1";"Su-17M2 Fitter-D"
+"su_17m2_2";"Su-17M2"
+#
+"su_17m4_shop";"Su-17M4 Fitter-K"
+"su_17m4_0";"OKB-51 ""Sukhoi"" | Su-17M4 Fitter-K"
+"su_17m4_1";"Su-17M4 Fitter-K"
+"su_17m4_2";"Su-17M4"
+#
+"su_22m3_shop";"Su-22M3 Fitter-G"
+"su_22m3_0";"OKB-51 ""Sukhoi"" | Su-22M3 Fitter-G"
+"su_22m3_1";"Su-22M3 Fitter-G"
+"su_22m3_2";"Su-22M3"
+#
+"su_24m_shop";"Su-24M Fencer-D"
+"su_24m_0";"PAO Kompaniya ""Sukhoi"" | Su-24M Fencer-D"
+"su_24m_1";"Su-24M Fencer-D"
+"su_24m_2";"Su-24M"
+#
+"su_34_shop";"Su-34M Sych"
+"su_34_0";"PAO Kompaniya ""Sukhoi"" | Su-34M Sych / Fullback"
+"su_34_1";"Su-34M Sych"
+"su_34_2";"Su-34M"
+#
+"mig-19pt_shop";"MiG-19PT Farmer-B"
+"mig-19pt_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-19PT Farmer-B"
+"mig-19pt_1";"MiG-19PT Farmer-B"
+"mig-19pt_2";"MiG-19PT"
+#
+"mig-21_f13_shop";"MiG-21F-13 Fishbed-C"
+"mig-21_f13_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-21F-13 Fishbed-C | Izdeliye 74"
+"mig-21_f13_1";"MiG-21F-13 Fishbed-C"
+"mig-21_f13_2";"MiG-21F-13"
+#
+"yak-30d_shop";"Yak-30D"
+"yak-30d_0";"OKB-115 ""Yakovlev"" | Yak-30D"
+"yak-30d_1";"Yak-30D"
+"yak-30d_2";"Yak-30D"
+#
+"yak-38_shop";"Yak-38 Forger"
+"yak-38_0";"OKB-115 ""Yakovlev"" | Yak-38 Forger"
+"yak-38_1";"Yak-38 Forger"
+"yak-38_2";"Yak-38"
+#
+"yak-38m_shop";"Yak-38M Forger-A"
+"yak-38m_0";"OKB-115 ""Yakovlev"" | Yak-38M Forger-A"
+"yak-38m_1";"Yak-38M Forger-A"
+"yak-38m_2";"Yak-38M"
+#
+"yak-28b_shop";"Yak-28B Brewer-A"
+"yak-28b_0";"OKB-115 ""Yakovlev"" | Yak-28B Brewer-A"
+"yak-28b_1";"Yak-28B Brewer-A"
+"yak-28b_2";"Yak-28B"
+#
+"yak_141_shop";"Yak-141 Freestyle"
+"yak_141_0";"OKB-115 ""Yakovlev"" | Yak-141 Freestyle"
+"yak_141_1";"Yak-141 Freestyle"
+"yak_141_2";"Yak-141"
+#
+"mig-17_shop";"MiG-17 Fresco-A"
+"mig-17_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-17 Fresco-A"
+"mig-17_1";"MiG-17 Fresco-A"
+"mig-17_2";"MiG-17"
+#
+"mig-17_cuba_shop";"MiG-17AS Fresco-A"
+"mig-17_cuba_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-17AS Fresco-A"
+"mig-17_cuba_1";"MiG-17AS Fresco-A"
+"mig-17_cuba_2";"MiG-17AS"
+#
+"mig-15_ns23_shop";"MiG-15 Fagot-A"
+"mig-15_ns23_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15 Fagot-A"
+"mig-15_ns23_1";"MiG-15 Fagot-A"
+"mig-15_ns23_2";"MiG-15"
+#
+"mig-15_shop";"MiG-15bis Fagot-B"
+"mig-15_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15bis Fagot-B"
+"mig-15_1";"MiG-15bis Fagot-B"
+"mig-15_2";"MiG-15bis"
+#
+"mig-15bis_ish_shop";"MiG-15ISh Fagot-B"
+"mig-15bis_ish_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-15ISh Fagot-B"
+"mig-15bis_ish_1";"MiG-15ISh Fagot-B"
+"mig-15bis_ish_2";"MiG-15ISh"
+#
+"yak-23_shop";"Yak-23 Flora"
+"yak-23_0";"OKB-115 ""Yakovlev"" | Yak-23 Flora"
+"yak-23_1";"Yak-23 Flora"
+"yak-23_2";"Yak-23"
+#
+"yak-15_shop";"Yak-15 Feather"
+"yak-15_0";"OKB-115 ""Yakovlev"" | Yak-15 Feather"
+"yak-15_1";"Yak-15 Feather"
+"yak-15_2";"Yak-15"
+#
+"yak-15_early_shop";"Yak-15-RD10 Feather"
+"yak-15_early_0";"OKB-115 ""Yakovlev"" | Yak-15-RD10 Feather"
+"yak-15_early_1";"Yak-15-RD10 Feather"
+"yak-15_early_2";"Yak-15-RD10"
+#
+"yak-17_shop";"Yak-17 Feather"
+"yak-17_0";"OKB-115 ""Yakovlev"" | Yak-17 Feather"
+"yak-17_1";"Yak-17 Feather"
+"yak-17_2";"Yak-17"
+#
+"mig-9_shop";"MiG-9 Fargo"
+"mig-9_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-9 Fargo"
+"mig-9_1";"MiG-9 Fargo"
+"mig-9_2";"MiG-9"
+#
+"mig-9_ussr_shop";"MiG-9 Fargo (1948)"
+"mig-9_ussr_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-9 Fargo (1948)"
+"mig-9_ussr_1";"MiG-9 Fargo (1948)"
+"mig-9_ussr_2";"MiG-9 (1948)"
+#
+"la_200_toriy_shop";"La-200 Toriy"
+"la_200_toriy_0";"OKB-301 ""Lavochkin"" | La-200 Toriy"
+"la_200_toriy_1";"La-200 Toriy"
+"la_200_toriy_2";"La-200"
+#
+"la-15_shop";"La-15 Fantail"
+"la-15_0";"OKB-301 ""Lavochkin"" | La-15 Fantail"
+"la-15_1";"La-15 Fantail"
+"la-15_2";"La-15"
+#
+"la_174_shop";"La-174 Fantail"
+"la_174_0";"OKB-301 ""Lavochkin"" | La-174 Fantail"
+"la_174_1";"La-174 Fantail"
+"la_174_2";"La-174"
+#
+"il_28_shop";"Il-28 Beagle-A"
+"il_28_0";"OKB-39 ""Ilyushin"" | Il-28 Beagle-A"
+"il_28_1";"Il-28 Beagle-A"
+"il_28_2";"Il-28"
+#
+"il_28sh_shop";"Il-28Sh Beagle-B"
+"il_28sh_0";"OKB-39 ""Ilyushin"" | Il-28Sh Beagle-B"
+"il_28sh_1";"Il-28Sh Beagle-B"
+"il_28sh_2";"Il-28Sh"
+#
+"su-11_shop";"Su-11 (1947)"
+"su-11_0";"OKB-51 ""Sukhoi"" | Su-11 | ""Aircraft KL"" (1947)"
+"su-11_1";"Su-11 (1947)"
+"su-11_2";"Su-11 (1947)"
+#
+"su-9_shop";"Su-9 (1946)"
+"su-9_0";"OKB-51 ""Sukhoi"" | Su-9 | ""Aircraft K"" (1946)"
+"su-9_1";"Su-9 (1946)"
+"su-9_2";"Su-9 (1946)"
+#
+"l_39za_shop";"▂L-39ZA Albatros"
+"l_39za_0";"▂Aero L-39ZA Albatros"
+"l_39za_1";"▂L-39ZA Albatros"
+"l_39za_2";"▂L-39ZA"
+#
+"mig_27m_shop";"MiG-27M Flogger-J"
+"mig_27m_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-27M Flogger-J"
+"mig_27m_1";"MiG-27M Flogger-J"
+"mig_27m_2";"MiG-27M"
+#
+"mig_27k_shop";"MiG-27K Flogger-J2"
+"mig_27k_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-27K Flogger-J2"
+"mig_27k_1";"MiG-27K Flogger-J2"
+"mig_27k_2";"MiG-27K"
+#
+"i-15_1934_shop";"I-15 Chaika (1933)"
+"i-15_1934_0";"N. Polikarpov OKB | I-15 Chaika (1933)"
+"i-15_1934_1";"I-15 Chaika (1933)"
+"i-15_1934_2";"I-15 (1933)"
+#
+"i-15_1935_shop";"I-15 Chaika (1934)"
+"i-15_1935_0";"N. Polikarpov OKB | I-15 Chaika (1934)"
+"i-15_1935_1";"I-15 Chaika (1934)"
+"i-15_1935_2";"I-15 (1934)"
+#
+"i-15_1935_moscow_shop";"I-15 Chaika (1936)"
+"i-15_1935_moscow_0";"N. Polikarpov OKB | I-15 Chaika (1936)"
+"i-15_1935_moscow_1";"I-15 Chaika (1936)"
+"i-15_1935_moscow_2";"I-15 (1936)"
+#
+"i-16_type5_shop";"I-16-5 Ishak"
+"i-16_type5_0";"N. Polikarpov OKB | I-16 Ishak | Type 5 (1935)"
+"i-16_type5_1";"I-16-5 Ishak"
+"i-16_type5_2";"I-16-5"
+#
+"i-16_type10_shop";"I-16-10 Ishak"
+"i-16_type10_0";"N. Polikarpov OKB | I-16 Ishak | Type 10 (1938)"
+"i-16_type10_1";"I-16-10 Ishak"
+"i-16_type10_2";"I-16-10"
+#
+"i-16_type18_shop";"I-16-18 Ishak"
+"i-16_type18_0";"N. Polikarpov OKB | I-16 Ishak | Type 18 (1939)"
+"i-16_type18_1";"I-16-18 Ishak"
+"i-16_type18_2";"I-16-18"
+#
+"i-16_type24_shop";"I-16-24 Ishak"
+"i-16_type24_0";"N. Polikarpov OKB | I-16 Ishak | Type 24 (1939)"
+"i-16_type24_1";"I-16-24 Ishak"
+"i-16_type24_2";"I-16-24"
+#
+"mig_3_series_1_15_shop";"I-230"
+"mig_3_series_1_15_0";"OKB-155 ""Mikoyan i Gurevich"" | I-230 | 1941 MiG-3U Prototype"
+"mig_3_series_1_15_1";"I-230"
+"mig_3_series_1_15_2";"I-230"
+#
+"i-15bis_shop";"I-15bis Chaika"
+"i-15bis_0";"N. Polikarpov OKB | I-15bis Chaika (1938)"
+"i-15bis_1";"I-15bis Chaika"
+"i-15bis_2";"I-15bis"
+#
+"i-153_m62_shop";"I-15-3/M-62 Chaika"
+"i-153_m62_0";"N. Polikarpov OKB | I-15 Chaika | Type 3 | M-62 Engine (1939)"
+"i-153_m62_1";"I-15-3/M-62 Chaika"
+"i-153_m62_2";"I-15-3/M-62"
+#
+"bb-1_shop";"BB-1"
+"bb-1_0";"OKB-51 Sukhoi | Blizhniy Bombardirovschik-1 | 1939 Su-2 Prototype"
+"bb-1_1";"BB-1"
+"bb-1_2";"BB-1"
+#
+"pe-3_early_shop";"Pe-3 Peshka (1941)"
+"pe-3_early_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3 Peshka (1941)"
+"pe-3_early_1";"Pe-3 Peshka (1941)"
+"pe-3_early_2";"Pe-3 (1941)"
+#
+"pe-3_shop";"Pe-3 Peshka (1942)"
+"pe-3_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3 Peshka (1942)"
+"pe-3_1";"Pe-3 Peshka (1942)"
+"pe-3_2";"Pe-3 (1942)"
+#
+"yak_2_kabb_shop";"Yak-2 KABB"
+"yak_2_kabb_0";"OKB-115 ""Yakovlev"" | Yak-2 | Kombinirovnnoy Artilleriysko Bombardirovochnoy Batareyey (1940)"
+"yak_2_kabb_1";"Yak-2 KABB"
+"yak_2_kabb_2";"Yak-2 KABB"
+#
+"sb_2m_100_shop";"SB (1936)"
+"sb_2m_100_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik (1936)"
+"sb_2m_100_1";"SB (1936)"
+"sb_2m_100_2";"SB (1936)"
+#
+"sb_2m_103c_shop";"SB (1938)"
+"sb_2m_103c_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik (1938)"
+"sb_2m_103c_1";"SB (1938)"
+"sb_2m_103c_2";"SB (1938)"
+#
+"yak-4_shop";"Yak-4"
+"yak-4_0";"OKB-115 ""Yakovlev"" | Yak-4"
+"yak-4_1";"Yak-4"
+"yak-4_2";"Yak-4"
+#
+"ar_2_shop";"Ar-2"
+"ar_2_0";"Tsentral'nyy Aerogidrodinamicheskiy Institut (TsAGI) | Ar-2"
+"ar_2_1";"Ar-2"
+"ar_2_2";"Ar-2"
+#
+"sb_2m_103u_shop";"SB-2M (1940)"
+"sb_2m_103u_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik-2M (1940)"
+"sb_2m_103u_1";"SB-2M (1940)"
+"sb_2m_103u_2";"SB-2M (1940)"
+#
+"sb_2m_105_shop";"SB-2M (1941)"
+"sb_2m_105_0";"OKB-156 ""Tupolev"" | Skorostnoi Bombardirovschik-2M (1941)"
+"sb_2m_105_1";"SB-2M (1941)"
+"sb_2m_105_2";"SB-2M (1941)"
+#
+"po-2_shop";"Po-2 Kukuruznik"
+"po-2_0";"N. Polikarpov OKB | Po-2 Kukuruznik (1929)"
+"po-2_1";"Po-2 Kukuruznik"
+"po-2_2";"Po-2"
+#
+"po-2m_shop";"Po-2M Kukuruznik"
+"po-2m_0";"N. Polikarpov OKB | Po-2M Kukuruznik (1931)"
+"po-2m_1";"Po-2M Kukuruznik "
+"po-2m_2";"Po-2M"
+#
+"su-2_m82_shop";"Su-2/M-82"
+"su-2_m82_0";"OKB-51 Sukhoi | Su-2 | M-82 Engine"
+"su-2_m82_1";"Su-2/M-82"
+"su-2_m82_2";"Su-2/M-82"
+#
+"su-2_mv5_shop";"Su-2 MV-5"
+"su-2_mv5_0";"OKB-51 Sukhoi | Su-2 | MV-5 Dorsal Turret"
+"su-2_mv5_1";"Su-2 MV-5"
+"su-2_mv5_2";"Su-2 MV-5"
+#
+"su-2_tss1_shop";"Su-2 TSS-1"
+"su-2_tss1_0";"OKB-51 Sukhoi | Su-2 | TSS-1 Turret"
+"su-2_tss1_1";"Su-2 TSS-1"
+"su-2_tss1_2";"Su-2 TSS-1"
+#
+"mbr-2_shop";"MBR-2bis Korova"
+"mbr-2_0";"OKB-49 Beriev | MBR-2bis Korova (1935)"
+"mbr-2_1";"MBR-2bis Korova"
+"mbr-2_2";"MBR-2bis"
+#
+"i-15bis_krasnolutsky_shop";"I-15bis [Krasnolutsky]"
+"i-15bis_krasnolutsky_0";"N. Polikarpov OKB | Krasnolutsky's I-15bis (1938)"
+"i-15bis_krasnolutsky_1";"I-15bis [Krasnolutsky]"
+"i-15bis_krasnolutsky_2";"I-15bis [Krasnolutsky]"
+#
+"pby-5a_shop";"▂PBY-5A Catalina"
+"pby-5a_0";"▂Consolidated Aircraft | PBY-5A Catalina"
+"pby-5a_1";"▂PBY-5A Catalina"
+"pby-5a_2";"▂PBY-5A"
+#
+"hp52_hampden_tbmk1_ussr_utk1_shop";"▂Hampden Mk.I UTK-1"
+"hp52_hampden_tbmk1_ussr_utk1_0";"▂Handley Page | HP.52 Hampden | Mk.I | UTK-1 Dorsal Turret"
+"hp52_hampden_tbmk1_ussr_utk1_1";"▂Hampden Mk.I UTK-1"
+"hp52_hampden_tbmk1_ussr_utk1_2";"▂Hampden Mk.I UTK-1"
+#
+"i-153_m62_zhukovskiy_shop";"I-153 Chaika [Zhukovsky]"
+"i-153_m62_zhukovskiy_0";"N. Polikarpov OKB | Zhukovsky's I-15 Chaika | Type 3 (1939)"
+"i-153_m62_zhukovskiy_1";"I-153 Chaika [Zhukovsky]"
+"i-153_m62_zhukovskiy_2";"I-153 [Zhukovsky]"
+#
+"p-40e_ussr_shop";"☭P-40E-1 Kittyhawk"
+"p-40e_ussr_0";"☭Curtiss-Wright Corporation | P-40E-1 Kittyhawk | Block 1"
+"p-40e_ussr_1";"☭P-40E-1 Kittyhawk"
+"p-40e_ussr_2";"☭P-40E-1"
+#
+"i_29_shop";"I-29"
+"i_29_0";"OKB-115 ""Yakovlev"" | I-29 (1940)"
+"i_29_1";"I-29"
+"i_29_2";"I-29"
+#
+"hurricanemkii_ussr_shop";"☭Hurricane Mk.IIB"
+"hurricanemkii_ussr_0";"☭Hawker Aircraft | Hurricane | Mk.IIB"
+"hurricanemkii_ussr_1";"☭Hurricane Mk.IIB"
+"hurricanemkii_ussr_2";"☭Hurricane Mk.IIB"
+#
+"il_2_m82_shop";"Il-2/M-82IR Sturmovik"
+"il_2_m82_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik | M-82IR Engine"
+"il_2_m82_1";"Il-2/M-82IR Sturmovik "
+"il_2_m82_2";"Il-2/M-82IR"
+#
+"i-153p_shop";"I-153P Chaika"
+"i-153p_0";"N. Polikarpov OKB | I-15 Chaika | Type 3 | Pushechnyy"
+"i-153p_1";"I-153P Chaika"
+"i-153p_2";"I-153P"
+#
+"i_180_shop";"I-180S"
+"i_180_0";"N. Polikarpov OKB | I-180S"
+"i_180_1";"I-180S"
+"i_180_2";"I-180S"
+#
+"p-39k_1_shop";"☭P-39K-1 Aircobra"
+"p-39k_1_0";"☭Bell Aircraft | P-39K-1 Aircobra | Model 26A"
+"p-39k_1_1";"☭P-39K-1 Aircobra"
+"p-39k_1_2";"☭P-39K-1"
+#
+"lagg-3-34_shop";"LaGG-3-34"
+"lagg-3-34_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 34th Series"
+"lagg-3-34_1";"LaGG-3-34"
+"lagg-3-34_2";"LaGG-3-34"
+#
+"lagg-i-301_shop";"I-301"
+"lagg-i-301_0";" OKB-301 ""Lavochkin"" | I-301 | 1940 LaGG-3 Prototype"
+"lagg-i-301_1";"I-301"
+"lagg-i-301_2";"I-301"
+#
+"yak-1_early_shop";"Yak-1"
+"yak-1_early_0";"OKB-115 ""Yakovlev"" | Yak-1"
+"yak-1_early_1";"Yak-1"
+"yak-1_early_2";"Yak-1"
+#
+"yak-1b_shop";"Yak-1B"
+"yak-1b_0";"OKB-115 ""Yakovlev"" | Yak-1B"
+"yak-1b_1";"Yak-1B"
+"yak-1b_2";"Yak-1B"
+#
+"yak-7b_shop";"Yak-7B"
+"yak-7b_0";"OKB-115 ""Yakovlev"" | Yak-7B"
+"yak-7b_1";"Yak-7B"
+"yak-7b_2";"Yak-7B"
+#
+"yak-9_shop";"Yak-9 "
+"yak-9_0";"OKB-115 ""Yakovlev"" | Yak-9"
+"yak-9_1";"Yak-9 "
+"yak-9_2";"Yak-9"
+#
+"yak-9b_shop";"Yak-9B"
+"yak-9b_0";"OKB-115 ""Yakovlev"" | Yak-9B"
+"yak-9b_1";"Yak-9B"
+"yak-9b_2";"Yak-9B"
+#
+"mig_3_series_1_15_bk_pod_shop";"I-230 (BK)"
+"mig_3_series_1_15_bk_pod_0";"OKB-155 ""Mikoyan i Gurevich"" | I-230 | MiG-3U Prototype | BK Gunpods"
+"mig_3_series_1_15_bk_pod_1";"I-230 (BK)"
+"mig_3_series_1_15_bk_pod_2";"I-230 (BK)"
+#
+"mig_3_series_34_shop";"MiG-3-34"
+"mig_3_series_34_0";"OKB-155 ""Mikoyan i Gurevich"" | MiG-3 | 34th Series"
+"mig_3_series_34_1";"MiG-3-34"
+"mig_3_series_34_2";"MiG-3-34"
+#
+"i-16_type27_shop";"I-16-27 Ishak"
+"i-16_type27_0";"N. Polikarpov OKB | I-16 Ishak | Type 27"
+"i-16_type27_1";"I-16-27 Ishak"
+"i-16_type27_2";"I-16-27"
+#
+"lagg-3-8_shop";"LaGG-3-8"
+"lagg-3-8_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 8th Series"
+"lagg-3-8_1";"LaGG-3-8"
+"lagg-3-8_2";"LaGG-3-8"
+#
+"lagg-3-11_shop";"LaGG-3-11"
+"lagg-3-11_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 11th Series"
+"lagg-3-11_1";"LaGG-3-11"
+"lagg-3-11_2";"LaGG-3-11"
+#
+"lagg-3-35_shop";"LaGG-3-35"
+"lagg-3-35_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 35th Series"
+"lagg-3-35_1";"LaGG-3-35"
+"lagg-3-35_2";"LaGG-3-35"
+#
+"lagg-3-66_shop";"LaGG-3-66"
+"lagg-3-66_0";"OKB-301 ""Lavochkin"" | LaGG-3 | 66th Series"
+"lagg-3-66_1";"LaGG-3-66"
+"lagg-3-66_2";"LaGG-3-66"
+#
+"la-5_shop";"La-5"
+"la-5_0";"OKB-301 ""Lavochkin"" | La-5"
+"la-5_1";"La-5"
+"la-5_2";"La-5"
+#
+"la-5_type39_shop";"La-5F"
+"la-5_type39_0";"OKB-301 ""Lavochkin"" | La-5F"
+"la-5_type39_1";"La-5F"
+"la-5_type39_2";"La-5F"
+#
+"il_2_1941_shop";"Il-2 Sturmovik (1941)"
+"il_2_1941_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik (1941)"
+"il_2_1941_1";"Il-2 Sturmovik (1941)"
+"il_2_1941_2";"Il-2 (1941)"
+#
+"il-2i_shop";"Il-2 Sturmovik (1942)"
+"il-2i_0";"OKB-39 ""Ilyushin"" | Il-2 Sturmovik (1942)"
+"il-2i_1";"Il-2 Sturmovik (1942)"
+"il-2i_2";"Il-2 (1942)"
+#
+"il_2_37_1943_shop";"Il-2M3M Sturmovik"
+"il_2_37_1943_0";"OKB-39 ""Ilyushin"" | Il-2M Sturmovik | Type 3M"
+"il_2_37_1943_1";"Il-2M3M Sturmovik"
+"il_2_37_1943_2";"Il-2M3M"
+#
+"pe-3_bis_shop";"Pe-3bis Peshka"
+"pe-3_bis_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-3bis Peshka"
+"pe-3_bis_1";"Pe-3bis Peshka"
+"pe-3_bis_2";"Pe-3bis"
+#
+"db_3b_shop";"DB-3B"
+"db_3b_0";"OKB-39 ""Ilyushin"" | Dalniy Bombardirovshchik-3B"
+"db_3b_1";"DB-3B"
+"db_3b_2";"DB-3B"
+#
+"il-4_shop";"Il-4 Bob"
+"il-4_0";"OKB-39 ""Ilyushin"" | Il-4 Bob"
+"il-4_1";"Il-4 Bob"
+"il-4_2";"Il-4"
+#
+"pe-2-1_shop";"Pe-2-1 Peshka"
+"pe-2-1_0";"NKVD Central Design Bureau №29 ""Petlyakov"" | Pe-2-1 Peshka"
+"pe-2-1_1";"Pe-2-1 Peshka"
+"pe-2-1_2";"Pe-2-1"
+#
+"su_30mk2v_venezuela_shop";"◡Su-30MK2 Flanker-G+"
+"su_30mk2v_venezuela_0";"PAO Kompaniya ""Sukhoi"" | ◡Su-30MK2 Flanker-G+"
+"su_30mk2v_venezuela_1";"◡Su-30MK2 Flanker-G+"
+"su_30mk2v_venezuela_2";"◡Su-30MK2"
+#
+"yak_1_litvyak_shop";"Yak-1 [Litvyak]"
+"yak_1_litvyak_0";"OKB-115 | S. A. Yakovlev | Litvyak's Yak-1"
+"yak_1_litvyak_1";"Yak-1 [Litvyak]"
+"yak_1_litvyak_2";"Yak-1 [Litvyak]"
+#
+mig_25pd_shop;MiG-25PD Foxbat-E
+mig_25pd_0;"OKB-155 ""Mikoyan i Gurevich"" | MiG-25PD Foxbat-E"
+mig_25pd_1;MiG-25PD Foxbat-E
+mig_25pd_2;MiG-25PD
+#
+su_30sm2_shop;Su-30SM2 Flanker-H
+su_30sm2_0;"PAO Kompaniya ""Sukhoi"" | Su-30SM2 Flanker-H"
+su_30sm2_1;Su-30SM2 Flanker-H
+su_30sm2_2;Su-30SM2
+#
+"shop/group/ar_group";"Ar-2/SB-2"
+"shop/group/db_3_group";"DB-3B/Il-4 Bob"
+"shop/group/il-2i_group";"Il-2 Sturmovik"
+"shop/group/la_5_group";"La-5/5F"
+"shop/group/yak-9tk_group";"Yak-9T/K"
+"shop/group/yak-3up_group";"Yak-3U/9UT"
+"shop/group/il_28_group";"Il-28 Beagle"
+"shop/group/la_200_group";"La-200/La-15"
+"shop/group/su-7_group";"Su-7B/BKL Fitter"
+"shop/group/mig-19_group";"MiG-19/MiG-21"
+"shop/group/mig_27_group";"MiG-27 Flogger"
+"shop/group/mig-23m_group";"MiG-23 Flogger"
+"shop/group/mig-21_group";"MiG-21 Fishbed"
+"shop/group/mig-15_group";"MiG-15 Fagot"
+"shop/group/mig-9_group";"MiG-9 Fargo"
+"shop/group/il-10_group";"Il-10 Beast"
+"shop/group/yak-1_group";"Yak-1"
+"shop/group/yak-9_group";"Yak-9/9B"
+"shop/group/yak-3_group";"Yak-3/9U"
+"shop/group/yak-9u_group";"Yak-9U"
+"shop/group/er-2_ach30b_group";"Yer-2/ACh-30B"
+"shop/group/lagg-3_late_group";"LaGG-3-35/66"
+"shop/group/pe-2_early_group";"Pe-2 Peshka (Early)"
+"shop/group/pe-2_late_group";"Pe-2 Peshka (Late)"
+"shop/group/tu-2_group";"Tu-2"
+"shop/group/er-2_late_group";"Yer-2/ACh-30B"
+"shop/group/il-2m_group";"Il-2M Sturmovik"
+"shop/group/lagg-3_group";"LaGG-3-8/11"

--- a/Mod Files/syrup_weapons.csv
+++ b/Mod Files/syrup_weapons.csv
@@ -1070,10 +1070,10 @@ weapons/us_aim92_stinger_right/short;AIM-92 ATAS
 "weapons/us_aim9b_fgw_2_sidewinder";"AIM-9F Sidewinder Air-to-Air Missile"
 "weapons/us_aim9b_fgw_2_sidewinder/short";"AIM-9F Sidewinder"
 #
-"us_iris_t_sl";"IRIS-T (Surface-Launched, Medium-Range)"
+"us_iris_t_sl";"IRIS-T SLM"
 "weapons/us_iris_t_sl/short";"IRIS-T SLM"
 #
-"weapons/180mm_IRIS_T_SL_user_cannon";"IRIS-T SLM"
+"weapons/180mm_IRIS_T_SL_user_cannon";"IRIS-T (Surface-Launched, Medium-Range)"
 #
 "weapons/sws_flz_lwf_63_80";"Flugzeug Lenkwaffe Luft-Luft 63/80 Air-to-Air Missile"
 "weapons/sws_flz_lwf_63_80/short";"Flz Lwf LL 63/80"
@@ -1227,7 +1227,7 @@ weapons/us_aim92_stinger_right/short;AIM-92 ATAS
 "weapons/su_r_27er1/short";"R-27ER1 Alamo-C"
 #
 weapons/209mm_9M33A3_launcher_user_cannon;9M33M3 Osa-AKM Surface-to-Air Missile
-209mm_9m33m3;9M33M3 Osa-AKM Surface-to-Air Missile
+209mm_9m33m3;9M33M3 Osa-AKM
 weapons/209mm_9m33m3/short;9M33M3 Osa-AKM
 #
 weapons/su_r_40rd;R-40RD Acrid-C Air-to-Air Missile
@@ -1395,6 +1395,24 @@ weapons/r_darter_default/short;R-Darter
 weapons/uk_brimstone_dm;Brimstone 2 Laser-Guided Air-to-Ground Missile
 weapons/uk_brimstone_dm/short;Brimstone 2 [SALH]
 #
+weapons/uk_sea_eagle;MBDA Sea Eagle missile
+weapons/uk_sea_eagle/short;MBDA Sea Eagle
+#
+weapons/uk_sea_eagle_wo_radar_designation;MBDA Sea Eagle missile
+weapons/uk_sea_eagle_wo_radar_designation/short;MBDA Sea Eagle
+#
+weapons/uk_firestreak;Firestreak air-to-air missiles
+weapons/uk_firestreak/short;Firestreak
+#
+weapons/uk_firestreak_default;Firestreak air-to-air missiles
+weapons/uk_firestreak_default/short;Firestreak
+#
+weapons/uk_firestreak_Javelin;Firestreak air-to-air missiles
+weapons/uk_firestreak_Javelin/short;Firestreak
+#
+weapons/uk_redtop;Red Top air-to-air missiles
+weapons/uk_redtop/short;Red Top
+#
 #Missiles, JP
 "weapons/us_aim9p4_sidewinder";"AIM-9P-4 Sidewinder Air-to-Air Missile"
 "weapons/us_aim9p4_sidewinder/short";"AIM-9P-4 Sidewinder"
@@ -1402,12 +1420,12 @@ weapons/uk_brimstone_dm/short;Brimstone 2 [SALH]
 "weapons/us_aim9p4_sidewinder_default";"AIM-9P-4 Sidewinder Air-to-Air Missile"
 "weapons/us_aim9p4_sidewinder_default/short";"AIM-9P-4 Sidewinder"
 #
-"160mm_sam_1c";"Type 81 Short-Range Surface-to-Air Missile, Model C (IR)"
-"160mm_sam_arh_1c";"Type 81 Short-Range Surface-to-Air Missile, Model C (ARH)"
+"160mm_sam_1c";"SAM-1C (IR)"
+"160mm_sam_arh_1c";"SAM-1C (ARH)"
 "weapons/160mm_sam_1c/short";"SAM-1C"
 #
-"weapons/160mm_sam_1c_launcher_user_cannon";"SAM-1C"
-"weapons/160mm_sam_1c_slave_launcher_user_cannon";"SAM-1C"
+"weapons/160mm_sam_1c_launcher_user_cannon";"Type 81 Short-Range Surface-to-Air Missile, Model C"
+"weapons/160mm_sam_1c_slave_launcher_user_cannon";"Type 81 Short-Range Surface-to-Air Missile, Model C"
 #
 "weapons/jp_aam3";"Type 90 Air-to-Air Guided Missile"
 "weapons/jp_aam3/short";"AAM-3"
@@ -1428,11 +1446,11 @@ weapons/uk_brimstone_dm/short;Brimstone 2 [SALH]
 "weapons/jp_asm2/short";"ASM-2"
 #
 #Missiles, CN
-"weapons/cn_pl12";"PL-12 Air-to-Air Missile"
-"weapons/cn_pl12/short";"PL-12"
+"weapons/cn_pl12";"PL-12 Adze Air-to-Air Missile"
+"weapons/cn_pl12/short";"PL-12 Adze"
 #
-"weapons/cn_pl12_default";"PL-12 Air-to-Air Missile"
-"weapons/cn_pl12_default/short";"PL-12"
+"weapons/cn_pl12_default";"PL-12 Adze Air-to-Air Missile"
+"weapons/cn_pl12_default/short";"PL-12 Adze"
 #
 "weapons/su_pl2";"PL-2 Atoll-C Air-to-Air Missile"
 "weapons/su_pl2/short";"PL-2 Atoll-C"
@@ -2114,6 +2132,97 @@ weapons/su_kab_1500lg_e/short;KAB-1500LG-E [1500kg]
 "weapons/uk_paveway_iv";"Paveway IV Dual-Mode Laser-Guided Bomb (500lb.)"
 "weapons/uk_paveway_iv/short";"Paveway IV (500lb.)"
 #
+weapons/uk_pgm_500;PGM 500 guided bomb
+weapons/uk_pgm_500/short;PGM 500
+#
+weapons/uk_pgm_2000;PGM 2000 guided bomb
+weapons/uk_pgm_2000/short;PGM 2000
+#
+weapons/uk_pgm_500_iir;PGM 500/3 guided bomb
+weapons/uk_pgm_500_iir/short;PGM 500/3
+#
+weapons/uk_pgm_2000_iir;PGM 2000/3 guided bomb
+weapons/uk_pgm_2000_iir/short;PGM 2000/3
+#
+weapons/uk_paveway_iv;Paveway IV guided bomb
+weapons/uk_paveway_iv/short;Paveway IV
+#
+weapons/uk_250lbs_late;G.P. 250 lb Mk.IV bomb
+weapons/uk_500lbs_43;G.P. 500 lb Mk.IV bomb
+#
+weapons/uk_250lbs_mc_mk1_mk2_bomb;M.C. 250 lb Mk.I bomb
+weapons/uk_250lbs_mc_mk1_mk2_bomb/short;M.C. 250 lb
+weapons/uk_250lbs_mc_mk1_mk2_bomb_default;M.C. 250 lb Mk.I bomb
+weapons/uk_250lbs_mc_mk1_mk2_bomb_default/short;M.C. 250 lb
+#
+weapons/uk_500lb_mc_mk1_mk4_long_tail_bomb;M.C. 500 lb Mk.I bomb
+weapons/uk_500lb_mc_mk1_mk4_long_tail_bomb/short;M.C. 500 lb
+#
+weapons/uk_1000lbs_mc_mk1_mk2_bomb;M.C. 1000 lb Mk.I bomb
+weapons/uk_1000lbs_mc_mk1_mk2_bomb/short;1000 lb
+#
+weapons/uk_520lb_herl_mk_1_n;HERL 520 lb Mk.IN bomb
+weapons/uk_520lb_herl_mk_1_n/short;HERL 520 lb Mk.IN
+#
+weapons/uk_1650lb_sn_he;1650 lb SNHE bomb
+weapons/uk_1650lb_sn_he/short;1650 lb SNHE
+#
+weapons/uk_250lbs/short;G.P. 250 lb
+weapons/uk_250lbs_43/short;G.P. 250 lb
+weapons/uk_250lbs_late/short;G.P. 250 lb
+#
+weapons/uk_500lbs/short;G.P. 500 lb
+weapons/uk_500lbs_43/short;G.P. 500 lb
+#
+weapons/uk_1000lbs_gp/short;G.P. 1000 lb
+weapons/uk_1000lbs_gp_mk1/short;G.P. 1000 lb
+weapons/uk_1000lbs_mc_mk1/short;M.C. 1000 lb
+#
+weapons/uk_mk2_cookie/short;H.C. 4000 lb
+#
+weapons/uk_12000lb_hc_mkI_n52_bomb;12000 lb H.C Mk.I bomb
+weapons/uk_12000lb_hc_mkI_n52_bomb/short;H.C. 12000 lb
+#
+weapons/uk_12000lb_hc_mkI_n33_bomb;12000 lb H.C Mk.I bomb
+weapons/uk_12000lb_hc_mkI_n33_bomb/short;H.C. 12000 lb
+#
+weapons/uk_8000lb_hc_mkI_n52_bomb;8000 lb H.C. Mk.II bomb
+weapons/uk_8000lb_hc_mkI_n52_bomb/short;H.C. 8000 lb
+#
+weapons/uk_8000lb_hc_mkI_n33_bomb;8000 lb H.C. Mk.II bomb
+weapons/uk_8000lb_hc_mkI_n33_bomb/short;H.C. 8000 lb
+#
+weapons/uk_4000lb_mc_mk1_mk2_bomb;4000 lb H.C. Mk.II bomb
+weapons/uk_4000lb_mc_mk1_mk2_bomb/short;H.C. 4000 lb
+#
+weapons/uk_4000lb_hc_mk4_bomb;4000 lb H.C. Mk.IV bomb
+weapons/uk_4000lb_hc_mk4_bomb/short;H.C. 4000 lb
+#
+weapons/uk_4000lb_hc_mk3_bomb;4000 lb H.C. Mk.III bomb
+weapons/uk_4000lb_hc_mk3_bomb/short;H.C. 4000 lb
+#
+weapons/uk_4000lb_hc_mk2_bomb;4000 lb H.C. Mk.II bomb
+weapons/uk_4000lb_hc_mk2_bomb/short;H.C. 4000 lb
+#
+weapons/uk_4000lb_hc_mk1_bomb;4000 lb H.C. Mk.I bomb
+weapons/uk_4000lb_hc_mk1_bomb/short;H.C. 4000 lb
+#
+weapons/uk_4000lb_gp_mk1_mk2_bomb;4000 lb H.C. Mk.II bomb
+weapons/uk_4000lb_gp_mk1_mk2_bomb/short;H.C. 4000 lb
+#
+weapons/uk_250lbs/short;G.P. 250 lb
+weapons/uk_250lbs_43/short;G.P. 250 lb
+weapons/uk_250lbs_late/short;G.P. 250 lb
+#
+weapons/uk_500lbs/short;G.P. 500 lb
+weapons/uk_500lbs_43/short;G.P. 500 lb
+#
+weapons/uk_1000lbs_gp/short;G.P. 1000 lb
+weapons/uk_1000lbs_gp_mk1/short;G.P. 1000 lb
+weapons/uk_1000lbs_mc_mk1/short;M.C. 1000 lb
+#
+weapons/uk_mk2_cookie/short;H.C. 4000 lb
+#
 #Bombs, JP
 "weapons/us_750lb_m117_cone_45_japan";"JM117 Low-Drag Demolition Bomb - Cone 45 (750lb.)"
 "weapons/us_750lb_m117_cone_45_japan/short";"JM117 (750lb.)"
@@ -2271,6 +2380,81 @@ weapons/su_s_8kom_rocket;S-8KOM 80mm High-Explosive Rocket
 #
 #Rocket, GB
 #
+weapons/uk_2_inch_rocket;RP rockets
+weapons/uk_2_inch_rocket/short;RP
+weapons/uk_2_inch_rocket_expo;RP rockets
+weapons/uk_2_inch_rocket_expo/short;RP
+#
+weapons/uk_180lb_triplex;Triplex R.P. rockets
+weapons/uk_180lb_triplex/short;Triplex R.P.
+#
+weapons/uk_uncle_tom_a;Uncle Tom rockets
+weapons/uk_uncle_tom_a/short;Uncle Tom
+weapons/uk_uncle_tom_b;Uncle Tom rockets
+weapons/uk_uncle_tom_b/short;Uncle Tom
+#
+weapons/uk_1000lb_ap_redangel;Red Angel rockets
+weapons/uk_1000lb_ap_redangel/short;Red Angel
+#
+weapons/uk_hvar;HVAR rockets
+weapons/uk_rocket;rocket
+#
+weapons/uk_rp3;RP-3 rockets
+weapons/uk_rp3_2;RP-3 rockets
+weapons/uk_rp3_3;RP-3 rockets
+#
+weapons/uk_rp3_4a;RP-3 rockets
+weapons/uk_rp3_4a_late;RP-3 rockets
+weapons/uk_rp3_4a_late/short;RP-3
+#
+weapons/uk_rp3_4a_default;RP-3 rockets
+weapons/uk_rp3_4a_default/short;RP-3
+#
+weapons/uk_rp3_4b;RP-3 rockets
+weapons/uk_rp3_4b_late;RP-3 rockets
+weapons/uk_rp3_4b_late/short;RP-3
+#
+weapons/uk_rp3_2_late;RP-3 rockets
+weapons/uk_rp3_2_late/short;RP-3
+#
+weapons/uk_rp3_late;RP-3 rockets
+weapons/uk_rp3_late/short;RP-3
+#
+weapons/uk_25lb_ap_mk1;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_1;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_1/short;AP Mk I
+#
+weapons/uk_25lb_ap_mk1_2;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_3;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_4a;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_4b;AP Mk I rockets
+#
+weapons/uk_25lb_ap_mk2;AP Mk II rockets
+weapons/uk_25lb_ap_mk2_late/short;AP Mk II
+weapons/uk_25lb_ap_mk2_late;AP Mk II rockets
+weapons/uk_25lb_ap_mk2_2;AP Mk II rockets
+weapons/uk_25lb_ap_mk2_3;AP Mk II rockets
+weapons/uk_25lb_ap_mk2_4a;AP Mk II rockets
+weapons/uk_25lb_ap_mk2_4b;AP Mk II rockets
+#
+weapons/uk_25lb_ap_mk1/short;AP Mk I
+weapons/uk_25lb_ap_mk1_2/short;AP Mk I
+weapons/uk_25lb_ap_mk1_3/short;AP Mk I
+weapons/uk_25lb_ap_mk1_4a/short;AP Mk I
+weapons/uk_25lb_ap_mk1_4b/short;AP Mk I
+#
+weapons/uk_25lb_ap_mk2/short;AP Mk II
+weapons/uk_25lb_ap_mk2_2/short;AP Mk II
+weapons/uk_25lb_ap_mk2_3/short;AP Mk II
+weapons/uk_25lb_ap_mk2_4a/short;AP Mk II
+weapons/uk_25lb_ap_mk2_4b/short;AP Mk II
+#
+weapons/uk_25lb_ap_mk1_4a_default;AP Mk I rockets
+weapons/uk_25lb_ap_mk1_4a_default/short;AP Mk I
+#
+weapons/uk_CRV7_m247;70 mm CRV7 M247 rocket
+weapons/uk_CRV7_m247/short;CRV7 M247
+#
 #Rocket, JP
 #
 #Rocket, CN
@@ -2363,4 +2547,57 @@ weapons/su_s_8kom_rocket;S-8KOM 80mm High-Explosive Rocket
 "weapons/us_750_gal_fastpack_f_15c_right";"Fuel And Sensor Tactical Pack"
 "weapons/us_750_gal_fastpack_f_15c_right/short";"FAST Pack"
 #
-
+#Torpedoes, UK
+weapons/uk_mk12_torpedo;18 inch Mark XII torpedo (1548 lbs)
+#
+weapons/uk_mk15_torpedo;18 inch Mark XV torpedo (1801 lbs)
+weapons/uk_mk15_torpedo_no_stab;18 inch Mark XV torpedo (1801 lbs)
+weapons/uk_mk15_torpedo_no_stab/short;Mark XV
+#
+weapons/uk_spearfish_torpedo;533 mm Spearfish torpedo
+weapons/uk_spearfish_torpedo/short;533 mm Spearfish
+#
+weapons/uk_450mm_18in_mk15_torpedo;450 mm Mk XV torpedo
+weapons/uk_450mm_18in_mk15_torpedo/short;Mk XV
+#
+weapons/uk_533mm_21in_mk8_torpedo;533 mm Mk.VIII torpedo
+weapons/uk_533mm_21in_mk8_torpedo/short;Mk.VIII
+#
+weapons/uk_533mm_21in_mk19_torpedo;533 mm Mk.IX torpedo
+weapons/uk_533mm_21in_mk19_torpedo/short;Mk.IX
+#
+weapons/uk_533mm_21in_mk5_torpedo;533 mm steam turbined Mk.V torpedo
+weapons/uk_533mm_21in_mk5_torpedo/short;Mk.V
+#
+weapons/uk_622mm_24_5in_mk1_torpedo;622 mm Mk.I torpedo
+weapons/uk_622mm_24_5in_mk1_torpedo/short;Mk.I
+#
+weapons/uk_450mm_18in_mk12_torpedo;18 inch Mk.XII torpedo
+weapons/uk_450mm_18in_mk12_torpedo/short;Mk.XII
+#
+weapons/uk_533mm_21in_mk9_torpedo;533 mm Mk.IX wet-heater torpedo
+weapons/uk_533mm_21in_mk9_torpedo/short;Mk.IX
+#
+weapons/uk_mine_type_a_mk1;1500 lbs Type A Mark I aircraft laid magnetic mine
+weapons/uk_mine_type_a_mk1/short;Type A Mk I
+#
+weapons/uk_mine_type_m_mk1;1123/1323 lbs Type M Mark I moored contact mine
+weapons/uk_mine_type_m_mk1/short;Type M Mk I
+#
+weapons/uk_mine_type_m_mk2;1760 lbs Type M Mark II magnetic ground mine
+weapons/uk_mine_type_m_mk2/short;Type M Mk II
+#
+weapons/uk_450mm_18in_rgf_mark6_hbh_torpedo;450 mm R.G.F. Mark VI** torpedo
+weapons/uk_450mm_18in_rgf_mark6_hbh_torpedo/short;450 mm Mark VI**
+#
+weapons/uk_533mm_21in_mk1_torpedo;21 inch Mark I torpedo
+weapons/uk_533mm_21in_mk1_torpedo/short;21 inch Mk.I
+#
+weapons/uk_533mm_21in_mk20e_bidder_torpedo;21 inch Mk.20 Bidder torpedo
+weapons/uk_533mm_21in_mk20e_bidder_torpedo/short;21 inch Mk.20
+#
+weapons/uk_533mm_21in_mk4_torpedo;533 mm Mk.IV torpedo
+weapons/uk_533mm_21in_mk4_torpedo/short;533 mm Mk.IV
+#
+weapons/uk_533mm_21in_mk9b_torpedo;533 mm Mk.IX** torpedo
+weapons/uk_533mm_21in_mk9b_torpedo/short;533 mm Mk.IX**


### PR DESCRIPTION
changed the names of Thai aircraft, Su-25s, J-11s, JH-7s, some American aircraft, and the Su-30MKV; removed NATO codenames from some culturally-significant Soviet WWII aircraft; fixed errors with the MiG-29G and Typhoon FGR.4 (ZK355); and tentatively fixed an error with SAMs displaying long names instead of short names in the killfeed | merged from maple-dev